### PR TITLE
fixed redundant primary nav underline for getting started link

### DIFF
--- a/source/stylesheets/test.css
+++ b/source/stylesheets/test.css
@@ -884,6 +884,12 @@ a {}
 	
 }
 
+/* quick fixes */
+
+li.header_menu_item.selected + li.header_menu_item.selected a {border: none !important;}
+
+
+
 /*gcs css fixes*/
 
 /*


### PR DESCRIPTION
Noticed that the green underline was appearing twice when on the getting started page. 