### PR TITLE
Multiple Inkling Tabs in Inkling Reference

### DIFF
--- a/source/includes/inkling-reference/_concept.html.md
+++ b/source/includes/inkling-reference/_concept.html.md
@@ -17,7 +17,7 @@ A concept statement describes what the computer will learn. It can be a feature 
 
 ### How Do I Use It?
 
-```inkling
+```inkling--code
 concept conceptName
   is classifier                 # or 'is estimator'
   predicts (outputSchema)
@@ -42,7 +42,7 @@ are explained in the following sections.
 
 ## Concept Statement Syntax
 
-```plaintext
+```inkling--syntax
 conceptStatement :=
 concept
   is [ classifier | estimator ]
@@ -74,7 +74,7 @@ sources and output targets.
 
 ### get_high_score
 
-```inkling
+```inkling--code
 concept get_high_score
   is classifier
   predicts PlayerMove
@@ -98,7 +98,7 @@ In this example:
 
 ### Digit
 
-```inkling
+```inkling--code
 concept Digit
   is classifier
   predicts MNIST_output
@@ -120,7 +120,7 @@ In this example:
 
 ### Curvature
 
-```inkling
+```inkling--code
 concept Curvature
   is classifier
   predicts (curve_output)
@@ -138,7 +138,7 @@ In this example:
 
 ### Segments
 
-```inkling
+```inkling--code
 concept Segments
   is classifier
   predicts (segments_output)

--- a/source/includes/inkling-reference/_curriculum.html.md
+++ b/source/includes/inkling-reference/_curriculum.html.md
@@ -12,7 +12,7 @@ A curriculum is used to teach a concept. The curriculum defines what concept is 
 
 ### How do I use it?
 
-```inkling
+```inkling--code
 curriculum curriculumName
   train conceptName
   with trainingSpecifier  # one of data, simulator, or generator
@@ -33,14 +33,14 @@ The `objective` specifies the termination condition for training.
 
 ### Mountain Car Example
 
-```inkling
+```inkling--code
 simulator mountaincar_simulator(MountainCarConfig) 
   state (GameState)
   control (Action)
 end
 ```
 
-```inkling
+```inkling--code
 curriculum high_score_curriculum
 train high_score
 with simulator mountaincar_simulator 
@@ -61,7 +61,7 @@ refer to it in our [Examples chapter][1].)
 
 The simulator clause declares the simulator name and two schemas. The first specifies the schema for configuration of the simulator and it appears in parentheses immediately after the simulator name. In this instance, the configuration schema is named `MountainCarConfig`. In the example, the configure clause of lesson `get_high_score` initializes this configuration.
 
-```inkling
+```inkling--code
 # Configuration schema declaration
 schema MountainCarConfig
   Int8 episode_length,
@@ -80,7 +80,7 @@ The second schema specified in the simulator clause is the state schema. It is
 specified after the **state** keyword in the simulator clause. This is the schema that defines what is sent to the lesson. Recall that a simulator has state. That means that input to the lesson will consist of the state of the game as a result of the previous lesson execution. For mountaincar this schema is called `GameState` and prior state consists of prior position.
 
 
-```inkling
+```inkling--code
 # State schema definition
 schema GameState
   Float32 x_position,
@@ -93,7 +93,7 @@ In order to determine what our next move will be, the training will use the prev
 Finally, note that `high_score_curriculum` trains a concept called `high_score`.  (It's quite clear what we are aiming for with this curriculum!)
 
 
-```inkling
+```inkling--code
 # Predict schema Action (see concept high_score)
 schema Action
   Int8{0, 1, 2} action # these values describe game moves
@@ -131,7 +131,7 @@ syntax for the curriculum statement, which introduces a **using** clause and a
 
 ## Curriculum Statement Syntax
 
-```plaintext
+```inkling--syntax
 curriculumStatement ::=
 curriculum <name>
     train <conceptName>
@@ -151,7 +151,7 @@ curriculum <name>
 end # curriculum
 ```
 
-```plaintext
+```inkling--syntax
 withClause ::=
 with data
   objective <objectiveFunctionName>
@@ -171,7 +171,7 @@ Any simulator or generator referenced in a curriculum must have an associated si
 
 Select the Inkling tab to see the Inkling code.
 
-```inkling
+```inkling--code
 curriculum get_high_score_curriculum
   train get_high_score
   with simulator breakout_simulator
@@ -194,7 +194,7 @@ In this example:
 
 ### digit_curriculum
 
-```inkling
+```inkling--code
 from utils import split
 
 schema MNIST_schema

--- a/source/includes/inkling-reference/_import.html.md
+++ b/source/includes/inkling-reference/_import.html.md
@@ -16,7 +16,7 @@ Note: Currently, the only function you can import is **split**.
 
 Select the Inkling tab to view two generic import statements.
 
-```inkling
+```inkling--code
 from libraryName import importName1
 import importName2
 ```
@@ -25,7 +25,7 @@ import importName2
 
 Select the Inkling tab to view the example of an imported function.
 
-```inkling
+```inkling--code
 from utils import split
 
   datastore MNIST_data(MNIST_training_data_schema)

--- a/source/includes/inkling-reference/_lesson.html.md
+++ b/source/includes/inkling-reference/_lesson.html.md
@@ -12,7 +12,7 @@ Lessons give you control over the training of the mental model. They allow you t
 
 ### How do I use it?
 
-```plaintext
+```inkling--syntax
 lesson lessonName
     follows prevLessonName
   configureClause
@@ -41,7 +41,7 @@ clause.
 
 ### Breakout Example
 
-```inkling
+```inkling--code
 schema BreakoutConfig   # configured in lesson configureClause
   UInt32 level,
   UInt8{1:4} paddle_width,
@@ -123,7 +123,7 @@ Lesson clauses have defaults so if a clause is not specified the default will be
 
 ## Lesson Syntax
 
-```plaintext
+```inkling--syntax
 lessonStatement ::=
   lesson <lessonName>
     [follows <lessonName>]?
@@ -138,7 +138,7 @@ clauses is displayed.
 
 ###### Lesson Configure Clause Syntax
 
-```plaintext
+```inkling--syntax
 configureClause ::=
 configure
   [constrain <configSchemaFieldName> with constrainedType]+
@@ -148,7 +148,7 @@ Select the Syntax tab for the syntax for this clause.
 
 ###### Lesson Train/Test Clause Syntax
 
-```plaintext
+```inkling--syntax
 trainClause ::=
 train
   fromClause
@@ -157,7 +157,7 @@ train
 trainingSpecifer
 ```
 
-```plaintext
+```inkling--syntax
 testClause ::=
 test
   fromClause
@@ -180,7 +180,7 @@ shows the usage of the **from** clause.
 
 ### Segments Example
 
-```inkling
+```inkling--code
 ‍generator segments_generator(UInt8 segmentCount)
   yield (segments_training_schema)     # training will yield data with this schema
 end
@@ -215,7 +215,7 @@ return. (The returned `num_segments` is expected to match the generator's
 
 ###### Lesson Until Clause Syntax
 
-```plaintext
+```inkling--syntax
 untilClause ::=
 until
       [ minimize | maximize ] <objectiveFunctionName>

--- a/source/includes/inkling-reference/_lexical.html.md
+++ b/source/includes/inkling-reference/_lexical.html.md
@@ -28,23 +28,22 @@ for use by Inkling and cannot be used as names in your program.
 
 **Keywords Table**
 
-
-               |                |                |                |                
--------------- | -------------- | -------------- | -------------- | -------------- 
-action | as | Bool | Byte | concept
-configure | constrain | copy | curriculum | data
-datastore | Double | easy | end | expect
-false | feeds | Float32 | Float64 | follows
-format | from | generator | hard | import
-in | Int16 | Int32 | Int64 | Int8
-into | is | lesson | let | Luminance
-Matrix | maximize | medium | minimize | objective
-predicts | schema | select | send | simulator
-state | stream | String | test | train
-true | UInt16 | UInt32 | UInt64 | UInt8
-unit | until | using | validate | where
-with | yield
-
+               |                |                |                |                |
+-------------- | -------------- | -------------- | -------------- | -------------- |
+action | and | as | Bool | Byte
+concept | configure | constrain | copy | curriculum
+data | datastore | debug | Double | easy
+end | expect | false | feeds | Float32
+Float64 | follows | format | from | generator
+hard | import | in | input | Int16
+Int32 | Int64 | Int8 | into | is
+lesson | let | Luminance | Matrix | maximize
+medium | minimize | not | objective | or
+output | predicts | schema | select | send
+simulator | state |  stream | String | test
+train | true | UInt16 | UInt32 | UInt64
+UInt8 | unit | until | using | validate
+where | with | yield
 
 ## Identifiers
 

--- a/source/includes/inkling-reference/_lexical.html.md
+++ b/source/includes/inkling-reference/_lexical.html.md
@@ -17,7 +17,7 @@ The lexical structure of Inkling includes these lexical elements:
 
 * An Inkling comment begins after the character **#** and extends to the end of the line.
 
-```inkling
+```inkling--code
   # this is a comment
 ```
 
@@ -70,7 +70,7 @@ point.
 Floating point literals can be Float32 or Float64 (double). Select the Inkling
 tab to see some floating point literals: 
 
-```inkling
+```inkling--code
  12.0, .5        # Float32 floating point literal
  1e7, 9e0        # Float64 (double) floating point literal
  13.0f7, .3f+2   # Float32 floating point literal

--- a/source/includes/inkling-reference/_schema.html.md
+++ b/source/includes/inkling-reference/_schema.html.md
@@ -15,7 +15,7 @@ example `concept` and `curriculum`) use schema references to describe the data t
 
 ### How do I use it?
 
-```inkling
+```inkling--code
 schema MySchema                   # declare
    UInt8  field1,
    UInt32 field2
@@ -42,7 +42,7 @@ pairs can appear where a schema name could appear.
 
 ## Schema Declaration Syntax
 
-```plaintext
+```inkling--syntax
 schemaStatement ::=
   schema <schemaName>
     fieldDeclarationList
@@ -96,7 +96,7 @@ In the syntax you will see references to Inkling primitive types and structure t
 ‍
 ## Schema Reference Syntax
 
-```plaintext
+```inkling--syntax
 schemaReference ::=
   '(' <name> ')'                  # named reference
   | 
@@ -109,7 +109,7 @@ A named schema is referenced by its name. An anonymous schema is referenced by i
 
 ## Schema Example
 
-```inkling
+```inkling--code
 schema MNIST_training_data_schema
   UInt8 label,
   Luminance(28, 28) image
@@ -122,7 +122,7 @@ Select the Inkling tab to show a schema that has a field with a primitive type a
 
 ###### Primitive Types
 
-```plaintext
+```inkling--syntax
 primitiveType ::=
   Double | Float64 | Float32 | Int8 | Int16 | Int32 |
   Int64 | UInt8 | UInt16 | UInt32  | UInt64 | Bool | String
@@ -134,7 +134,7 @@ with 'U' are unsigned.
 
 ###### Structured Types
 
-```plaintext
+```inkling--syntax
 structure_type ::= 
   Luminance | Matrix
 ```
@@ -147,7 +147,7 @@ See the schema declaration syntax for the complete syntax of structure declarati
 ‍
 ###### Constrained Types
 
-```inkling
+```inkling--code
   # Example: Range expression
 
   schema Schema1
@@ -169,7 +169,7 @@ Select the Inkling tab to see an example of a constrained type in a schema defin
 
 ### Constrained Type Syntax
 
-```plaintext
+```inkling--syntax
 constrainedType ::=
 primitiveType
 '{'
@@ -190,7 +190,7 @@ Note that start, stop, step, numSteps are all numeric literals.
 There are three forms of range expressions which Inkling supports. 
 Select the Inkling tab to see an example of each type.
 
-```inkling
+```inkling--code
 # Example: Value list range expression
 schema Schema2
   UInt8  {0,1,2,3,4}   num, # a set of UInt8 values
@@ -204,7 +204,7 @@ A value list range expression is simply a list of values.
 These range expressions specify sets of values in 
 which each value is explicitly listed.
 
-```inkling
+```inkling--code
 # Example: Range expression, colon range type
 schema Schema3
   Int64  { 0:5:100 }   x,   # start:step:stop, step= 5,0..100
@@ -221,7 +221,7 @@ the step, and the stop.
 * Step can be  a floating point number.
 * The step size can be negative only if stop < start.
 
-```inkling
+```inkling--code
 # Example: Range expression, dot range type
 schema Schema4
   Int64  { 0..100:25 } z,   # start:stop, numsteps=25
@@ -242,7 +242,7 @@ The range start point is exact (to the maximum extent possible if the range expr
 
 * **Numeric Range Expression End Point**
 
-```inkling
+```inkling--code
  # Valid and Invalid Range Expressions.
 
  Int64  { 0:4:1 }  field1,  # INVALID. step size > range.

--- a/source/includes/inkling-reference/_training-sources.html.md
+++ b/source/includes/inkling-reference/_training-sources.html.md
@@ -28,7 +28,7 @@ Currently, during our private beta, you can <b>only</b> train with simulators as
 
 ## Simulator Clause Syntax
 
-```plaintext
+```inkling--syntax
 simulator <simulatorName>'('<configurationSchema>')' 
   state '('<stateSchema>')'     # simulator state
   control '('<controlSchema>')' # training concept predicts schema
@@ -49,7 +49,7 @@ The [Mountain Car example][4] of a simulator below shows the implementation of t
 
 ## Generator Clause Syntax
 
-```plaintext
+```inkling--syntax
 generator <generatorName>'('<configurationSchema>')'  
   yield '('<outputSchema>')'    # generator output (yield)
 end

--- a/source/references/inkling-reference.html.md
+++ b/source/references/inkling-reference.html.md
@@ -2,8 +2,8 @@
 title: Inkling Reference - Bonsai
 
 language_tabs:
-  - inkling: Inkling
-  - plaintext: Syntax
+  - inkling--code
+  - inkling--syntax
 
 toc_footers:
   - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>

--- a/source/references/inkling-reference.html.md
+++ b/source/references/inkling-reference.html.md
@@ -2,8 +2,8 @@
 title: Inkling Reference - Bonsai
 
 language_tabs:
-  - inkling--code
-  - inkling--syntax
+  - inkling--code: Inkling
+  - inkling--syntax: Syntax
 
 toc_footers:
   - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>


### PR DESCRIPTION
Update the Inkling Reference to use multi-language tabs for inkling on both code and syntax.

Also updated the keywords table with the latest reserved words.

PR Review Checklist:
[X] Test search functionality by pressing enter on mobile/desktop
[X] Test search functionality by clicking search icon on mobile/desktop
[X] Test filter functionality
[X] Test mobile header navigation
[X] Test desktop header navigation
[X] Test desktop homepage navigation
[X] Run blc http://localhost:4567/ -ro (runs broken-link-checker on whatever port you're using)