### PR TITLE
Add back beta as Bonsai Platform preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ You'll want to go to http://docs.bons.ai/ for the compiled version. This project
 
 Check out [Slate](lord.github.io/slate).
 
-**Where do I go to get into the Bonsai private beta?**
+**Where do I go to get into the Bonsai Platform preview?**
 
-[Apply here](http://pages.bons.ai/apply.html) for access to our private beta.
+[Apply here](http://pages.bons.ai/apply.html) for access to our preview of the Bonsai Platform.
 
 ## If You Want to Contribute
 ------------------------------

--- a/source/examples.html.md
+++ b/source/examples.html.md
@@ -1,15 +1,10 @@
 ---
 title: Examples
 
-language_tabs:
-
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
-  - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
+  -  <%= partial "partials/footer-links" %>
 
 includes:
-
 - examples/overview.html.md
 - examples/find-the-center.html.md
 - examples/cart-pole.html.md

--- a/source/guides/ai-engine-guide.html.md
+++ b/source/guides/ai-engine-guide.html.md
@@ -1,15 +1,10 @@
 ---
 title: AI Engine Guide
 
-language_tabs:
-
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
-  - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
+  -  <%= partial "partials/footer-links" %>
 
 includes:
-
 - under-the-hood.html.md
 
 search: true

--- a/source/guides/cli-guide.html.md
+++ b/source/guides/cli-guide.html.md
@@ -6,11 +6,7 @@ language_tabs:
     - shell: macOS
 
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
-  -  <%= partial "partials/footer-links" %>
-
-
+  -  <%= partial "partials/footer-links" %>    
 
 includes:
   - cli-guide/cli-overview.html.md

--- a/source/guides/getting-started.html.md
+++ b/source/guides/getting-started.html.md
@@ -2,11 +2,7 @@
 title: Quick Start
 
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
   -  <%= partial "partials/footer-links" %>
-
-
 
 includes:
   - getting-started/overview.html.md

--- a/source/guides/inkling-guide.html.md
+++ b/source/guides/inkling-guide.html.md
@@ -1,12 +1,8 @@
 ---
 title: Inkling Guide
 
-language_tabs:
-
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
-  - <a href='https://github.com/lord/slate'>Documentation Powered by Slate</a>
+  -  <%= partial "partials/footer-links" %>
 
 includes:
 - inkling-guide/overview.html.md

--- a/source/includes/cli-guide/_install.html.md
+++ b/source/includes/cli-guide/_install.html.md
@@ -2,7 +2,7 @@
 
 [//]: # (If any commented statements become false, change prior text)
 
-Before you begin, you will need to have access to our Beta. If you don't have access yet, request access at [bons.ai][1].
+Before you begin, you will need to have access to the Bonsai Platform preview. If you don't have access yet, request access at [bons.ai][1].
 
 The next section walks you through how to install Git, Python, and pip, but if you're already ahead of the curve and **have them all installed**, skip down to [Setup the Bonsai CLI][2]. 
 

--- a/source/includes/getting-started/_overview.html.md
+++ b/source/includes/getting-started/_overview.html.md
@@ -34,7 +34,7 @@ be using a simple simulator from OpenAI. Simulators usually have state, which is
 world inside the virtual environment and receive actions which change that state.
 
 <aside class="notice">
-Currently, during our beta, you can only use simulators as your training source. Generators
+Currently, during the Bonsai Platform preview, you can only use simulators as your training source. Generators
 and Data sources will be released at a future time.
 </aside> 
 

--- a/source/includes/getting-started/_quick-start.html.md
+++ b/source/includes/getting-started/_quick-start.html.md
@@ -3,7 +3,7 @@
 > Open AI's Cartpole Gym
 > ![Cartpole Trained][12]
 
-Before you begin, you will need to have access to our private beta. If you don't have access yet,
+Before you begin, you will need to have access to the Bonsai Platform preview. If you don't have access yet,
 request access at [bons.ai][1].
 
 In this guide, we’ll walk you through creating a BRAIN to train the [OpenAI Gym][4] environment for

--- a/source/includes/inkling-guide/_curriculum-and-lessons.html.md
+++ b/source/includes/inkling-guide/_curriculum-and-lessons.html.md
@@ -5,7 +5,7 @@ A **curriculum** in Inkling is used to define what and how to teach a concept. E
 Curriculum contain the lesson plan for the lessons that you are using to train your BRAINs. You must have one curriculum for every concept. A curriculum contains information about the training material that you're using to train the BRAIN; this is a simulator, generator, or data set, and it contains an objective, which measures the performance of the BRAIN as it learns your concept. Curricula may also contain expressions that assign portions of your training material for testing. Finally, your curriculum contains lessons. Each lesson teaches a piece of the concept. A curriculum can contain multiple lessons to teach a single concept.  Each lesson may contain different configurations for training the BRAIN. Configurations change how the Bonsai AI Engine uses the training source for training.
 
 <aside class="notice">
-Currently, during our private beta, you can only train with simulators as your training sources. Additionally, you are limited to one lesson in your curriculum.
+Currently, during the Bonsai Platform preview, you can only train with simulators as your training sources. Additionally, you are limited to one lesson in your curriculum.
 </aside> 
 
 ## Determining Curriculum

--- a/source/includes/inkling-reference/_lesson.html.md
+++ b/source/includes/inkling-reference/_lesson.html.md
@@ -114,7 +114,7 @@ Lesson clauses have defaults so if a clause is not specified the default will be
 **simulator** | Required.    | If neither train nor test is present, defaults to: *item in simulator select item send item*. | If neither train nor test is present, defaults to: *from item in simulator select item*. If not present, generate default for every lesson. | Required.
 
 <aside class="notice">
-Currently, during our private beta, you can only use simulators as your training source.
+Currently, during the Bonsai Platform preview, you can only use simulators as your training source.
 </aside> 
 
 ###### Lesson Clause Rules

--- a/source/includes/inkling-reference/_training-source.html.md
+++ b/source/includes/inkling-reference/_training-source.html.md
@@ -3,7 +3,7 @@
 The Bonsai Platform supports training with both real and synthetic data. The `data`, `simulator` and `generator` keywords are used to describe what kind of training source you would like to use for training.
 
 <aside class="notice">
-Currently, during our private beta, you can <b>only</b> train with simulators as your training source. That is, only the <i>simulator</i> training specifier is supported.
+Currently, during the Bonsai Platform preview, you can <b>only</b> train with simulators as your training source. That is, only the <i>simulator</i> training specifier is supported.
 </aside>
 
 ### Simulators
@@ -17,7 +17,7 @@ Our [Library Reference][1] describes the classes and methods used to connect an 
 Generators produce labeled data programmatically. This data is effectively infinite. A generator could, for example, produce a random (but known) integer, set of line segments, etc.
 
 <aside class="notice">
-Currently, during our private beta, you can <b>only</b> train with simulators as your training source. That is <i>generators</i> are not supported.
+Currently, during the Bonsai Platform preview, you can <b>only</b> train with simulators as your training source. That is <i>generators</i> are not supported.
 </aside>
 
 ### Data
@@ -25,7 +25,7 @@ Currently, during our private beta, you can <b>only</b> train with simulators as
 Data is information related to the scenario being trained comprising of columns of information with input values and expected labels or desired predicted values. Data is used both for training and evaluating the quality of training. Examples of training data include a collection of images and labels or the rows and columns of a spreadsheet.
 
 <aside class="notice">
-Currently, during our private beta, you can <b>only</b> train with simulators as your training source. That is <i>data</i> is not supported.
+Currently, during the Bonsai Platform preview, you can <b>only</b> train with simulators as your training source. That is <i>data</i> is not supported.
 </aside>
 
 ## Simulator Clause Syntax

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -122,6 +122,7 @@
 
 					<div class="footer-links-home flex-footer stretched">
 						<a href="https://bons.ai">Bonsai Home</a>
+						<a href="http://pages.bons.ai/apply.html">Apply for Bonsai Platform Preview</a>
 						<a class="flex-cc" href="https://github.com/BonsaiAI/slate">Contribute to the Docs on GitHub</a>
 						
 						

--- a/source/partials/_footer-links.erb
+++ b/source/partials/_footer-links.erb
@@ -3,6 +3,7 @@
 
 
 <li><a href='https://github.com/BonsaiAI/slate'>Contribute to the Docs</a></li>
+<li><a href='http://pages.bons.ai/apply.html'>Apply for Bonsai Platform Preview</a></li>
 <li><a href='http://forums.bons.ai/'>Bonsai Forums</a></li>
 <li><a href='https://bons.ai/contact-us#contact-page-form'>Contact Us</a></li>
 <li><a href='https://bons.ai'>Bonsai Home</a></li>

--- a/source/references/api-reference.html.md
+++ b/source/references/api-reference.html.md
@@ -2,11 +2,7 @@
 title: API Reference
 
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
   -  <%= partial "partials/footer-links" %>
-
-
 
 includes:
   - api-reference/api-reference.html.md

--- a/source/references/cli-reference.html.md
+++ b/source/references/cli-reference.html.md
@@ -6,11 +6,7 @@ language_tabs:
    - shell: macOS
 
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
-  -  <%= partial "partials/footer-links" %>
-
-
+   -  <%= partial "partials/footer-links" %>  
 
 includes:
   - cli-reference/cli-reference.html.md

--- a/source/references/inkling-reference.html.md
+++ b/source/references/inkling-reference.html.md
@@ -6,11 +6,7 @@ language_tabs:
   - inkling--syntax: Syntax
 
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
-  -  <%= partial "partials/footer-links" %>
-
-
+  -  <%= partial "partials/footer-links" %>  
 
 includes:
 - inkling-reference/inkling-reference.html.md

--- a/source/references/library-reference.html.md
+++ b/source/references/library-reference.html.md
@@ -5,8 +5,6 @@ language_tabs:
   - python
 
 toc_footers:
-  - <a href='https://bons.ai/sign-up'>Sign Up for our Private Beta!</a>
-  - <a href='.'>Return home</a>
   -  <%= partial "partials/footer-links" %>
 
 


### PR DESCRIPTION
This PR is for adding a link back to the documentation website for people to be able to sign up for the beta now called "Bonsai Platform preview", but only via the documentation website.

Also changed:
* Cleaned up footer links
* Cleaned up links to apply website

PR Review Checklist:
- [x] Test search functionality on desktop
- [x] Test search functionality on tablet
- [x] Test search functionality on mobile
- [x] Test filter functionality
- [x] Test mobile header navigation
- [x] Test tablet header navigation
- [x] Test desktop header navigation
- [x] Test desktop homepage navigation
- [x] Run blc http://localhost:4567/ -ro (runs broken-link-checker on whatever port you're using)
