### PR TITLE
Add CHANGELOG link to CLI Ref

### DIFF
--- a/source/includes/cli-reference/_cli-reference.html.md
+++ b/source/includes/cli-reference/_cli-reference.html.md
@@ -1,3 +1,7 @@
 # CLI Overview
 
 The Bonsai Command Line Interface (CLI) is a text-based tool that enables you to configure and control the Bonsai Artificial Intelligence Engine. The CLI is especially useful for automation and connection to other tools. Currently, there are some actions that can only be performed using the CLI, such as loading your Inkling file and connecting your simulator. 
+
+For information about changes in each CLI release, please refer to the [CLI CHANGELOG][1] on GitHub.
+
+[1]: https://github.com/BonsaiAI/bonsai-cli/blob/master/CHANGELOG.md


### PR DESCRIPTION
Small change to add a link somewhere in the docs. I think this is the best place, and keep it short and sweet.

What do you think?
