### PR TITLE
Add documentation for Managed Simulators

### DIFF
--- a/source/includes/cli-reference/_projectfile.html.md
+++ b/source/includes/cli-reference/_projectfile.html.md
@@ -58,7 +58,6 @@ Current list of supported simulators for Docker cloud-hosted training:
  * [`openai.gym`][1]
  * [`bonsai.python`][2]
  * [`bonsai.energyplus`][3]
- * `bonsai.gazebo`
 
 ## .brains file
 
@@ -83,6 +82,6 @@ project file.
    operations.
 
 
-[1]: https://github.com/BonsaiAI/bonsai-gym-common
-[2]: https://github.com/BonsaiAI/bonsai-python
-[3]: https://github.com/BonsaiAI/energyplus-sample
+[1]: https://quay.io/repository/bonsai/gym
+[2]: https://quay.io/repository/bonsai/python
+[3]: https://quay.io/repository/bonsai/energyplus

--- a/source/includes/cli-reference/_projectfile.html.md
+++ b/source/includes/cli-reference/_projectfile.html.md
@@ -53,6 +53,13 @@ There must be at least one valid path in the `files` list.
 points to a pre-configured simulation container inside the platform. The
 `command` field describes the command to run to start the simulator.
 
+Current list of supported simulators for Docker cloud-hosted training:
+
+ * [`openai.gym`][1]
+ * [`bonsai.python`][2]
+ * [`bonsai.energyplus`][3]
+ * `bonsai.gazebo`
+
 ## .brains file
 
 ```json
@@ -74,3 +81,8 @@ project file.
 
  * `default` marks a named BRAIN as the default BRAIN to use with command
    operations.
+
+
+[1]: https://github.com/BonsaiAI/bonsai-gym-common
+[2]: https://github.com/BonsaiAI/bonsai-python
+[3]: https://github.com/BonsaiAI/energyplus-sample

--- a/source/includes/examples/_cart-pole.html.md
+++ b/source/includes/examples/_cart-pole.html.md
@@ -2,7 +2,7 @@
 
 > ![Cart Pole Balance](../images/cart-pole-balance.gif)
 
-[**Download the full source code on GitHub**][1] if you want to run this simulator locally or create a new BRAIN on [beta.bons.ai][4] to run it yourself on the Bonsai Platform.
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally. If you want to run Cart Pole remotely on the Bonsai Platform as a managed simulator, create a new BRAIN selecting the Cart Pole demo on [beta.bons.ai][4].
 
 In this example, we'll walk you through the various statements that are part of the Cart Pole Inkling file. Each statement is followed by an explanation of the statement.
 

--- a/source/includes/examples/_cart-pole.html.md
+++ b/source/includes/examples/_cart-pole.html.md
@@ -2,7 +2,7 @@
 
 > ![Cart Pole Balance](../images/cart-pole-balance.gif)
 
-[**Download the full source code on GitHub**][1] so you can run it yourself on the Bonsai Platform.
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally or create a new BRAIN on [beta.bons.ai][4] to run it yourself on the Bonsai Platform.
 
 In this example, we'll walk you through the various statements that are part of the Cart Pole Inkling file. Each statement is followed by an explanation of the statement.
 
@@ -124,3 +124,4 @@ This is an OpenAI Gym example which uses the OpenAI environment as its simulator
 [1]: https://github.com/BonsaiAI/gym-cartpole-sample
 [2]: https://gym.openai.com/envs/CartPole-v1
 [3]: https://github.com/BonsaiAI/bonsai-gym-common
+[4]: https://beta.bons.ai/new

--- a/source/includes/examples/_energyplus.html.md
+++ b/source/includes/examples/_energyplus.html.md
@@ -2,7 +2,7 @@
 
 > ![EnergyPlus Graph](../images/energyplus-graph.png)
 
-[**Download the full source code on GitHub**][1] so you can run it yourself on the Bonsai Platform.
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally or create a new BRAIN on [beta.bons.ai][4] to run it yourself on the Bonsai Platform.
 
 In this example, we'll walk you through the various statements that are part of a sample implementation of [EnergyPlus][2] on the Bonsai Platform, including the simulator and the Inkling files. This is a real-world example of how to use the Bonsai Platform for HVAC control using BCVTB and EnergyPlus.
 
@@ -236,3 +236,4 @@ For more information on the functions inside of this simulator class and how to 
 [1]: https://github.com/BonsaiAI/energyplus-sample
 [2]: https://energyplus.net/
 [3]: http://docs.bons.ai/references/library-reference.html
+[4]: https://beta.bons.ai/new

--- a/source/includes/examples/_energyplus.html.md
+++ b/source/includes/examples/_energyplus.html.md
@@ -2,7 +2,7 @@
 
 > ![EnergyPlus Graph](../images/energyplus-graph.png)
 
-[**Download the full source code on GitHub**][1] if you want to run this simulator locally or create a new BRAIN on [beta.bons.ai][4] to run it yourself on the Bonsai Platform.
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally. If you want to run Cart Pole remotely on the Bonsai Platform as a managed simulator, create a new BRAIN selecting the Cart Pole demo on [beta.bons.ai][4].
 
 In this example, we'll walk you through the various statements that are part of a sample implementation of [EnergyPlus][2] on the Bonsai Platform, including the simulator and the Inkling files. This is a real-world example of how to use the Bonsai Platform for HVAC control using BCVTB and EnergyPlus.
 

--- a/source/includes/examples/_energyplus.html.md
+++ b/source/includes/examples/_energyplus.html.md
@@ -2,7 +2,7 @@
 
 > ![EnergyPlus Graph](../images/energyplus-graph.png)
 
-[**Download the full source code on GitHub**][1] if you want to run this simulator locally. If you want to run Cart Pole remotely on the Bonsai Platform as a managed simulator, create a new BRAIN selecting the Cart Pole demo on [beta.bons.ai][4].
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally. If you want to run EnergyPlus remotely on the Bonsai Platform as a managed simulator, create a new BRAIN selecting the EnergyPlus demo on [beta.bons.ai][4].
 
 In this example, we'll walk you through the various statements that are part of a sample implementation of [EnergyPlus][2] on the Bonsai Platform, including the simulator and the Inkling files. This is a real-world example of how to use the Bonsai Platform for HVAC control using BCVTB and EnergyPlus.
 

--- a/source/includes/examples/_find-the-center.html.md
+++ b/source/includes/examples/_find-the-center.html.md
@@ -2,7 +2,7 @@
 
 > ![Find the Center Diagram](../images/find-the-center.png)
 
-[**Download the full source code on GitHub**][1] if you want to run this simulator locally on the Bonsai Platform.
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally.
 
 In this example, we'll walk you through the various statements that are part of the *Find the Center* game, including the python simulator file and the Inkling file. This is a very basic example of Inkling and how to connect to a custom python simulator.
 

--- a/source/includes/examples/_find-the-center.html.md
+++ b/source/includes/examples/_find-the-center.html.md
@@ -2,7 +2,7 @@
 
 > ![Find the Center Diagram](../images/find-the-center.png)
 
-[**Download the full source code on GitHub**][1] so you can run it yourself on the Bonsai Platform.
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally on the Bonsai Platform.
 
 In this example, we'll walk you through the various statements that are part of the *Find the Center* game, including the python simulator file and the Inkling file. This is a very basic example of Inkling and how to connect to a custom python simulator.
 

--- a/source/includes/examples/_mountain-car.html.md
+++ b/source/includes/examples/_mountain-car.html.md
@@ -2,7 +2,7 @@
 
 > ![Mountain Car Control](../images/mountain-car-control.gif)
 
-[**Download the full source code on GitHub**][1] if you want to run this simulator locally or create a new BRAIN on [beta.bons.ai][4] to run it yourself on the Bonsai Platform.
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally. If you want to run Mountain Car remotely on the Bonsai Platform as a managed simulator, create a new BRAIN selecting the Mountain Car demo on [beta.bons.ai][4]
 
 We've used pieces of code from this example in several places, but here we'll walk you through all the various statements that are part of the Mountain Car Inkling file. Each statement is followed by an explanation of the statement.
 

--- a/source/includes/examples/_mountain-car.html.md
+++ b/source/includes/examples/_mountain-car.html.md
@@ -2,7 +2,7 @@
 
 > ![Mountain Car Control](../images/mountain-car-control.gif)
 
-[**Download the full source code on GitHub**][1] so you can run it yourself on the Bonsai Platform.
+[**Download the full source code on GitHub**][1] if you want to run this simulator locally or create a new BRAIN on [beta.bons.ai][4] to run it yourself on the Bonsai Platform.
 
 We've used pieces of code from this example in several places, but here we'll walk you through all the various statements that are part of the Mountain Car Inkling file. Each statement is followed by an explanation of the statement.
 
@@ -121,3 +121,5 @@ This is an OpenAI Gym example which uses the OpenAI environment as its simulator
 [1]: https://github.com/BonsaiAI/gym-mountaincar-sample
 [2]: https://gym.openai.com/envs/MountainCar-v0
 [3]: https://github.com/BonsaiAI/bonsai-gym-common
+[4]: https://beta.bons.ai/new
+

--- a/source/includes/examples/_overview.html.md
+++ b/source/includes/examples/_overview.html.md
@@ -2,6 +2,8 @@
 
 This page contains working examples of Inkling code in conjunction with python simulator files. All of these examples and the libraries that accompany them can be found on [BonsaiAI's GitHub page][1] and are also linked within each Example.
 
+All of the **OpenAI Gym Examples** and **EnergyPlus** can be trained in the cloud with Bonsai Managed Simulators. A full list of supported Docker containers for Managed Simulators can be found on [Quay][3].
+
 If you have any suggestions of examples you'd like to see us implement please [contact the support team][2].
 
 ### Basic Walkthrough Examples
@@ -16,3 +18,4 @@ If you have any suggestions of examples you'd like to see us implement please [c
 
 [1]: https://github.com/BonsaiAI
 [2]: https://bons.ai/contact-us#contact-page-form
+[3]: https://quay.io/organization/bonsai

--- a/source/includes/examples/_overview.html.md
+++ b/source/includes/examples/_overview.html.md
@@ -2,7 +2,7 @@
 
 This page contains working examples of Inkling code in conjunction with python simulator files. All of these examples and the libraries that accompany them can be found on [BonsaiAI's GitHub page][1] and are also linked within each Example.
 
-All of the **OpenAI Gym Examples** and **EnergyPlus** can be trained in the cloud with Bonsai Managed Simulators. A full list of supported Docker containers for Managed Simulators can be found on [Quay][3].
+All of the **OpenAI Gym Examples** and **EnergyPlus** can be trained in the cloud with Bonsai managed simulators. A full list of supported Docker containers for remotely managed simulators can be found in the [Project File Reference][3].
 
 If you have any suggestions of examples you'd like to see us implement please [contact the support team][2].
 
@@ -18,4 +18,4 @@ If you have any suggestions of examples you'd like to see us implement please [c
 
 [1]: https://github.com/BonsaiAI
 [2]: https://bons.ai/contact-us#contact-page-form
-[3]: https://quay.io/organization/bonsai
+[3]: ../references/cli-reference.html#bproj-file


### PR DESCRIPTION
Updated the Examples page and the CLI Reference with mention of Managed Simulators.

@matt-haigh to double check my verbiage on "cloud-hosted" and other mentions of Docker containers.
