### PR TITLE
T2563 Remove num_episodes

### DIFF
--- a/source/includes/examples/_cart-pole.html.md
+++ b/source/includes/examples/_cart-pole.html.md
@@ -36,12 +36,11 @@ The schema `Action` names a record — `action` —  and assigns it a constraine
 ```inkling
 schema CartPoleConfig
   Int8 episode_length,
-  Int8 num_episodes,
   UInt8 deque_size
 end
 ```
 
- The schema `CartPoleConfig` names three records — `episode_length`, `num_episodes`, and `deque_size` — and assigns each of them a type.
+ The schema `CartPoleConfig` names two records — `episode_length` and `deque_size` — and assigns each of them a type.
 
 ###### Concept
 
@@ -75,8 +74,7 @@ curriculum balance_curriculum
   objective up_time
   lesson balancing
     configure
-      constrain episode_length with Int8{-1}
-      constrain num_episodes with Int8{-1}
+      constrain episode_length with Int8{-1},
       constrain deque_size with UInt8{1}
     until
       maximize up_time
@@ -85,7 +83,7 @@ end
 
 The curriculum's name is `balance_curriculum`. It trains the `balance` concept with the `cartpole_simulator`. The objective for this curriculum is `up_time`. The objective measures how long the pole stays upright.
 
-This curriculum contains one lesson, called `balancing`. It configures the simulation, by setting a number of constraints for the state of the simulator. The lesson trains until the AI has maximized the objective.
+This curriculum contains one lesson, called `balancing`. It configures the simulation, by setting two constraints for the state of the simulator. The lesson trains until the AI has maximized the objective.
 
 ## Simulator File
 

--- a/source/includes/examples/_mountain-car.html.md
+++ b/source/includes/examples/_mountain-car.html.md
@@ -34,12 +34,11 @@ The `Action` schema names a single record — `action` — and assigns a constra
 ```inkling
 schema MountainCarConfig
   Int8 episode_legnth,
-  Int8 num_episodes,
   UInt8 deque_size
 end
 ```
 
-The `MountainCarConfig` schema names three records — `episode_length`, `num_episodes`, and `deque_size` — and assigns types to them.
+The `MountainCarConfig` schema names two records — `episode_length` and `deque_size` — and assigns types to them.
 
 ###### Concept
 
@@ -74,14 +73,13 @@ curriculum high_score_curriculum
   lesson get_high_score
     configure
       constrain episode_length with Int8{-1},
-      constrain num_episodes with Int8{-1},
       constrain deque_size with UInt8{1}
     until
       maximize score
 end
 ```
 
-The curriculum is named `high_score_curriculum`, and it trains the `high_score` concept using the `mountaincar_simulator`. This curriculum contains one lesson, called `get_high_score`. It configures the simulation, by setting a number of constraints for the state of the simulator.
+The curriculum is named `high_score_curriculum`, and it trains the `high_score` concept using the `mountaincar_simulator`. This curriculum contains one lesson, called `get_high_score`. It configures the simulation, by setting two constraints for the state of the simulator.
 
 The lesson trains until the AI has maximized the objective named `score`.
 

--- a/source/includes/inkling-guide/_curriculum-and-lessons.html.md
+++ b/source/includes/inkling-guide/_curriculum-and-lessons.html.md
@@ -37,7 +37,6 @@ The configure clause uses the **constrain** keyword to create a set of condition
 lesson get_high_score
   configure
     constrain episode_length with Int8{-1},
-    constrain num_episodes with Int8{-1},
     constrain deque_size with UInt8{1}
   until
     maximize open_ai_gym_default_objective

--- a/source/includes/inkling-reference/_curriculum.html.md
+++ b/source/includes/inkling-reference/_curriculum.html.md
@@ -48,7 +48,6 @@ objective open_ai_gym_default_objective
   lesson get_high_score
     configure
       constrain episode_length with Int8{-1},
-      constrain num_episodes with Int8{-1},
       constrain deque_size with UInt8{1}
     until
       maximize open_ai_gym_default_objective
@@ -65,7 +64,6 @@ The simulator clause declares the simulator name and two schemas. The first spec
 # Configuration schema declaration
 schema MountainCarConfig
   Int8 episode_length,
-  Int8 num_episodes,
   UInt8 deque_size
 end
 ```


### PR DESCRIPTION
Remove num_episodes in the two OpenAI Gym examples in the docs as well as mentions in the Inkling reference and guide.

Do not merge until T2563 is released to beta.