### PR TITLE
Update Curriculums Reference Section

### DIFF
--- a/source/includes/inkling-reference/_curriculums.html.md
+++ b/source/includes/inkling-reference/_curriculums.html.md
@@ -1,19 +1,29 @@
 # Curriculums
 
-The keyword `curriculum` declares a set of lessons that are used to teach concepts. Each `curriculum` contains a `lesson` or set of lessons and trains a single `concept`.
+```inkling--code
+curriculum MyCurriculum
+  train MyConcept
+  with simulator MySimulator
+  objective MyObjective
+    # lessons are specified here.
+end
+```
 
-A curriculum is used to teach a concept. The curriculum defines what concept is being taught. Every concept needs a corresponding curriculum to teach it. A curriculum defines a set of lessons used to train the concept.
+The Inkling curriculum statement is used to specify the training of Inkling concepts. 
 
-> Curriculum (top level) Syntax
+The curriculum specifies the concept which is being taught. (Every
+concept needs a corresponding curriculum to teach it.) The lessons defined within
+the curriculum are used to train that concept.
+
+> Curriculum Syntax
 
 ```inkling--syntax
-curriculumStmt ::=
-curriculum <name>
-    train <conceptName>
-[
-  withClause                        # with clause
-
-]+
+curriculum <name>                            
+train  <conceptName>                        
+[ 
+  with simulator <simulatorName>  
+  objective <objectiveFunctionName> 
+]+ 
 [
   using <simulatorName>             # using clause
   [
@@ -25,36 +35,18 @@ curriculum <name>
 end # curriculum
 ```   
 
-```inkling--code
-curriculum curriculumName
-  train conceptName
-  with trainingSpecifier  # one of data, simulator, or generator
-  objective objectiveName
-    # lessons are specified here.
-end
-```
+The `train` keyword indicates which concept this curriculum trains and the
+`objective` keyword specifies the objective function.  This function specifies the termination condition for training.
 
-The `train` keyword indicates which concept this curriculum trains, the _with data_ keywords specify that training with labeled data should be used with this curriculum, and the _objective_ keyword specifies the objective function used to evaluate the learning system&#39;s performance.
+The lessons contained in the `using` clause form a directed graph for use by the instructor.
 
-Curricula contain one or more lessons which themselves form a directed graph for use by the instructor.
-
-The _trainingSpecifier_ specifies either `data`, `simulator`, or `generator` as the training source. Refer back to [Training Source][2] for more information on what the differences are.
-
-<aside class="notice">
-Currently, only simulator training sources are supported. When the <i>trainingspecifier</i> is <b>simulator</b>, the objective names a function which is specified in the associated simulator. The use of simulators requires an auxiliary <i>simulator</i> clause. 
-</aside>
-
-The `objective` specifies the termination condition for training.
+There can be only one curriculum per concept.
 
 
 
 **(Previously there was a ### Rules section, do we want that?)**
 
-There can be only one curriculum per concept.
 
-Lessons, tests, and assignments can occur in any order.
-
-The test clause is optional for any particular lesson. However if the last lesson has no test clause it is an error.
 
 The `follows` clause on the lesson is optional. Note that if there is no `follows` clause and the lessons are executed in parallel, training will be slower.
 

--- a/source/includes/inkling-reference/_curriculums.html.md
+++ b/source/includes/inkling-reference/_curriculums.html.md
@@ -9,7 +9,7 @@ curriculum MyCurriculum
 end
 ```
 
-The Inkling curriculum statement is used to specify the training of Inkling concepts. 
+The `curriculum` statement is used to specify the training of Inkling concepts. 
 
 The curriculum specifies the concept which is being taught. 
 The lessons defined within the curriculum are used to train that concept.
@@ -24,14 +24,15 @@ train  <conceptName>
   objective <objectiveFunctionName> 
 ]+ 
 [
-  using <simulatorName>             # using clause
+  using <simulatorName>         # using clause
   [
-    lessonClause # lesson set for this simulator
+    lessonClause                # lesson set for this simulator
   ]+
-  end # using
+  end
 ]+
-end # curriculum
+end
 ```   
+
 ### Usage
 
 There can be only one curriculum per concept.
@@ -52,7 +53,7 @@ clause for every simulator specified in the `with simulator` clause.
 
 ### Discussion
 
-The concept graph is laid out by the architect and then handed to the
+The concept graph is laid out by the [architect][] and then handed to the
 instructor. The instructor will look for the starting point among the concepts and
 their corresponding curriculums, and then will use the curriculum to train
 the concept.
@@ -75,7 +76,7 @@ simulator breakout_simulator(BreakoutConfig)
 end
 ```
 
-The simulator clause declares the simulator name and several schemas. The first
+The `simulator` clause declares the simulator name and several schemas. The first
 schema specifies the schema for configuration of the simulator and it appears in
 parentheses immediately after the simulator name. In this instance, the
 configuration schema is named `BreakoutConfig`. In the example, the configure
@@ -129,7 +130,7 @@ selection of the next move.
 ```inkling--code
 # predict schema for high_score and action schema for simulator
 schema PlayerMove               # action schema
-    Int8{-1, 0, 1} move         # these values describe game moves
+    Int8{-1, 0, 1} move         # possible game moves
 end
 
 concept high_score is classifier
@@ -141,7 +142,7 @@ end
 
 The `action` schema (which is `PlayerMove`) is the third schema specified in the simulator clause.
 The simulator `action` schema must match the `predicts` schema of the concept being trained.
-In our example the concept `high_score` trains the Brain to select the next move, which will have
+In our example the concept `high_score` trains the BRAIN to select the next move, which will have
 one of the values specified in the `PlayerMove` schema range expression. 
 
 ```inkling--code

--- a/source/includes/inkling-reference/_curriculums.html.md
+++ b/source/includes/inkling-reference/_curriculums.html.md
@@ -11,9 +11,8 @@ end
 
 The Inkling curriculum statement is used to specify the training of Inkling concepts. 
 
-The curriculum specifies the concept which is being taught. (Every
-concept needs a corresponding curriculum to teach it.) The lessons defined within
-the curriculum are used to train that concept.
+The curriculum specifies the concept which is being taught. 
+The lessons defined within the curriculum are used to train that concept.
 
 > Curriculum Syntax
 
@@ -29,313 +28,154 @@ train  <conceptName>
   [
     lessonClause # lesson set for this simulator
   ]+
-
   end # using
 ]+
 end # curriculum
 ```   
-
-The `train` keyword indicates which concept this curriculum trains and the
-`objective` keyword specifies the objective function.  This function specifies the termination condition for training.
-
-The lessons contained in the `using` clause form a directed graph for use by the instructor.
+### Usage
 
 There can be only one curriculum per concept.
 
+Every concept must have a curriculum.
 
+Every simulator must be declared with a simulator clause.
 
-**(Previously there was a ### Rules section, do we want that?)**
+The `train` keyword indicates which concept this curriculum trains.
 
+The `objective` keyword specifies the objective function.  This function
+specifies the termination condition for training. It is always required. 
 
-
-The `follows` clause on the lesson is optional. Note that if there is no `follows` clause and the lessons are executed in parallel, training will be slower.
-
-If the usingClause is present (that is, if the simplified curriculum syntax is not being used), there must be one usingClause for every withClause.
-
----------> Current web rules section below
-
-* One curriculum per concept. 
-* Every concept must have a curriculum.
-* Every simulator must be declared with a [simulator clause][3].
-* Lessons and tests can occur in any order.
-* If the **using** clause is present (that is, if the simplified curriculum syntax is not being used), there must be one **using** clause for every **with** clause.
-* The objective is always required.
+If the curriculum uses one simulator, the `using simulator` clause is optional. For more
+than one simulator, the `using simulator` clause is required to associate a lesson set
+with a specified simulator. In that case, there must be one `using simulator` 
+clause for every simulator specified in the `with simulator` clause. 
 
 ### Discussion
 
-```inkling--syntax
-curriculum <name>                              # single curriculum                    
-train  <conceptName>                           # single concept   
-[ 
-  with simulator <simulatorName>  
-  objective <objectiveFunctionName> 
-]+ 
-```
+The concept graph is laid out by the architect and then handed to the
+instructor. The instructor will look for the starting point among the concepts and
+their corresponding curriculums, and then will use the curriculum to train
+the concept.
 
-The architect hands the instructor a laid out concept graph. The instructor will look for starting point among the concepts and their corresponding curriculums. At the highest level the instructor will use the curriculum to train the concept; thus there is one curriculum per concept. Note how the curriculum syntax associates a curriculum with a single concept.
+A curriculum (and its concept) is associated with a set of simulators and each
+simulator has an objective function and a schema. The instructor trains each
+concept using a simulator with the specified objective function. 
 
-A curriculum (and its concept) is associated with a set of simulators and each simulator has an objective function and a schema. The instructor trains each concept using a simulator with a dedicated objective function. The schema used in the curriculum statement identifies placeholders. Placeholders are discussed in the [lessons][] section.
-
-### Mountain Car Example
-
-```inkling--code
-simulator mountaincar_simulator(MountainCarConfig) 
-  state (GameState)
-  control (Action)
-end
-```
-
-```inkling--code
-curriculum high_score_curriculum
-train high_score
-with simulator mountaincar_simulator 
-objective open_ai_gym_default_objective
-  lesson get_high_score
-    configure
-      constrain episode_length with Int8{-1},
-      constrain num_episodes with Int8{-1},
-      constrain deque_size with UInt8{1}
-    until
-      maximize open_ai_gym_default_objective
-end
-```
-
-Select the Inkling tab to view an excerpt of the code in the game Mountain Car from
-OpenAI Gym as written in Inkling. This illustrates the [simulator clause][3].  (To explore this example more fully,
-refer to it in our [Examples chapter][1].)
-
-The simulator clause declares the simulator name and two schemas. The first specifies the schema for configuration of the simulator and it appears in parentheses immediately after the simulator name. In this instance, the configuration schema is named `MountainCarConfig`. In the example, the configure clause of lesson `get_high_score` initializes this configuration.
-
-```inkling--code
-# Configuration schema declaration
-schema MountainCarConfig
-  Int8 episode_length,
-  Int8 num_episodes,
-  UInt8 deque_size
-end
-```
-
-The names in the configuration schema are the names referenced in the configure
-clause of `lesson get_high_score`. When the lesson is
-initiated, the configuration data as described in the configuration schema is sent
-to the simulator. The configuration data will be generated according to the
-range expression in the lesson configure clause for a field. 
-
-The second schema specified in the simulator clause is the state schema. It is
-specified after the **state** keyword in the simulator clause. This is the schema that defines what is sent to the lesson. Recall that a simulator has state. That means that input to the lesson will consist of the state of the game as a result of the previous lesson execution. For mountaincar this schema is called `GameState` and prior state consists of prior position.
-
-
-```inkling--code
-# State schema definition
-schema GameState
-  Float32 x_position,
-  Float32 x_velocity
-end
-```
-
-In order to determine what our next move will be, the training will use the previous position as input.
-
-Finally, note that `high_score_curriculum` trains a concept called `high_score`.  (It's quite clear what we are aiming for with this curriculum!)
-
-
-```inkling--code
-# Predict schema Action (see concept high_score)
-schema Action
-  Int8{0, 1, 2} action # these values describe game moves
-end
-
-concept high_score
-  is classifier
-  predicts (Action)
-  follows input(GameState)    
-  feeds output
-end
-```
-
-The concept `high_score` trains the Brain to select the next move, which will have
-one of the values specified in the `Action` schema range expression. 
-
-Note that the predefined stream **input** has the schema `GameState`. This reflects that fact that the simulator has state. The previous move is the state which is input into the selection of the next move.
-
-The **predicts** schema `Action` also appears in the simulator clause discussed above. It is after the keyword **control**. In general the **control** schema is the **predicts** schema of the concept being trained.
-
-So far we have presented a simple version of the curriculum. Inkling supports
-multiple simulators and generators within a single curriculum. Here is the full
-syntax for the curriculum statement, which introduces a **using** clause and a
-**with** clause (where **using** and **with** will specify simulators). These were not needed in our example above because we were using a single simulator.
+The lesson clause configures the lesson and describes training and the objective. For more information see the section on [lessons][].
 
 
 ### Breakout Example
 
-[This is what was in OneNote. Do we want to use this one or the Mountain Car example? We could use this one in the reference and just link to Mountain Car but it has more text around it to explain. Up to you.]
-
-Here is a concept and its curriculum for training for the computer game breakout. It is simplified but shows the various Inkling statements and includes some code fragments for a python simulator.  Included are the curriculum, lessons,  concepts, schemas, and simulator. (This example uses compiler version 1.1.1 syntax.) 
-
-As there is only one simulator, this example uses the simplified syntax where 'using <simulatorName>' is unnecessary.  
+> Breakout Example
 
 ```inkling--code
 simulator breakout_simulator(BreakoutConfig) 
-   state (GameState) 
-   action(PlayerMove) 
-end 
-schema GameState 
-  Luminance(84, 336) pixels 
-end 
- 
-schema PlayerMove 
-  Int8{-1, 0, 1} move 
-end 
- 
-schema BreakoutConfig 
-  UInt32 level, 
-  UInt8{1:4} paddle_width, 
-  Float32 bricks_percent 
-end 
- 
-concept ball_location is estimator 
-  predicts (Matrix(UInt32, 1, 2) location) 
-  follows input(GameState) 
-end 
-concept keep_paddle_under_ball is classifier 
-    predicts (PlayerMove) 
-  follows ball_location, input(GameState) 
-end 
-concept high_score is classifier 
-  predicts (PlayerMove) 
-  follows keep_paddle_under_ball, input(GameState) 
-  feeds output 
-end 
- 
-curriculum ball_location_curriculum 
-  train ball_location 
-  with simulator breakout_simulator 
-  objective ball_location_distance 
-    lesson no_bricks 
-      configure 
-        constrain bricks_percent with Float32{0.0}, 
-        constrain level with UInt32{1}, 
-        constrain paddle_width with UInt8{4} 
-      train 
-        from frame in breakout_simulator 
-        select frame 
-        send frame 
-      test 
-        from frame in breakout_simulator 
-        select frame 
-        send frame 
-      until 
-        minimize ball_location_distance 
- 
-    lesson more_bricks follows no_bricks 
-      configure 
-        constrain bricks_percent with Float32{0.1:0.01:1.0}, 
-        constrain level with UInt32{1:100}, 
-        constrain paddle_width with UInt8{1:4} 
-      train 
-        from frame in breakout_simulator 
-        select frame 
-        send frame 
-      test 
-        from frame in breakout_simulator 
-        select frame 
-        send frame 
-      until 
-        minimize ball_location_distance 
-end 
- 
-curriculum keep_paddle_under_ball_curriculum 
-  train keep_paddle_under_ball 
-  with simulator breakout_simulator 
-  objective ball_paddle_distance 
-    lesson track_ball 
-      configure 
-        constrain bricks_percent with Float32{1.0}, 
-        constrain level with UInt32{1:100}, 
-        constrain paddle_width with UInt8{1:4} 
-      train 
-        from frame in breakout_simulator 
-        select frame 
-        send frame 
-      test 
-        from frame in breakout_simulator 
-        select frame 
-        send frame 
-      until 
-        minimize ball_paddle_distance 
-end 
- 
-curriculum high_score_curriculum 
-  train high_score 
-  with simulator breakout_simulator 
-  objective score 
-    lesson score_lesson 
-      configure 
-        constrain bricks_percent with Float32{1.0}, 
-        constrain level with UInt32{1:100}, 
-        constrain paddle_width with UInt8{1:4} 
-      train 
-        from frame in breakout_simulator 
-        select frame 
-        send frame 
-      test 
-        from frame in breakout_simulator 
-        select frame 
-        send frame 
-      until 
-        maximize score 
+  action  (PlayerMove)
+  state  (GameState)
 end
 ```
 
+The simulator clause declares the simulator name and several schemas. The first
+schema specifies the schema for configuration of the simulator and it appears in
+parentheses immediately after the simulator name. In this instance, the
+configuration schema is named `BreakoutConfig`. In the example, the configure
+clauses of the lessons initializes the configuration schema fields of `BreakoutConfig`.
 
-## Curriculum Subclauses 
 
-The curriculum statement has subclauses including the withClause and the lessonClause.
+```inkling--code
+schema BreakoutConfig
+    UInt16 level,
+    UInt8{1:4} paddle_width,
+    Float32 bricks_percent
+end
 
-### With Clause
+schema GameState                # state schema
+    Luminance(84, 336) pixels
+end
 
-The set of withClauses specifies the set of simulators this curriculum will use. The usingClause associates a set of lessons with each simulator.  
- 
-There is a simplified syntax for the curriculum in which the usingClause is not necessary because the curriculum contains only one simulator.  
-
-> With Clause Syntax
-
-```inkling--syntax
-curriculumStmt :=  
-curriculum <name>                      
-   train  <conceptName>    
-   withClause 
-   [                                                           
-      assignClause       
-      lessonClause 
-   ]+ 
-end   # curriculum
+curriculum high_score_curriculum
+  train high_score
+  with simulator breakout_simulator
+  objective score
+    lesson score_lesson
+      configure
+        constrain bricks_percent with Float32{1.0},
+        constrain level with UInt16{1:100},
+        constrain paddle_width with UInt8{1:4}
+      until
+        maximize score
+end
 ```
 
----------> Current web syntax
+The names in the configuration schema `BreakoutConfig` are the names referenced in the configure
+clause of the lessons. When a lesson is initiated, the configuration data as described 
+in the configuration schema is sent
+to the simulator. The configuration data will be generated according to the
+range expression in the lesson configure clause for a field. 
 
-```inkling--syntax
-withClause ::=
-with simulator
-  objective <objectiveFunctionName>
+The second schema specified in the simulator clause is the `state` schema. It is
+specified after the `state` keyword in the simulator clause. This is the schema
+that defines what is sent to the lesson. Recall that a simulator has state. That
+means that input to the lesson will consist of the state of the game as a result
+of the previous lesson execution. For Breakout this schema is called
+`GameState`. The `Luminance` field in `GameState` describes the state of play in
+pixels. 
+
+The simulator `state` schema
+must match the schema associated with `input` for the system.
+This reflects the fact that the state is the input to the simulator for 
+selection of the next move.
+
+```inkling--code
+# predict schema for high_score and action schema for simulator
+schema PlayerMove               # action schema
+    Int8{-1, 0, 1} move         # these values describe game moves
+end
+
+concept high_score is classifier
+  predicts (PlayerMove)
+  follows keep_paddle_under_ball, input(GameState)
+  feeds output
+end
 ```
 
-The withClause specifies the simulators.
+The `action` schema (which is `PlayerMove`) is the third schema specified in the simulator clause.
+The simulator `action` schema must match the `predicts` schema of the concept being trained.
+In our example the concept `high_score` trains the Brain to select the next move, which will have
+one of the values specified in the `PlayerMove` schema range expression. 
 
-[Can we get rid of data and generator and just keep simulator?]
+```inkling--code
+concept keep_paddle_under_ball is classifier
+  predicts (PlayerMove)
+  follows input(GameState)
+end
 
-The keyword **data** indicates that this is batch based training using labeled data. This is generally accompanied with the assignClause which specifies how to prepare the training data. The type of training is time invariant. Training will result in a classifier. In this case the training does not use coded simulators.
+curriculum keep_paddle_under_ball_curriculum
+  train keep_paddle_under_ball
+  with simulator breakout_simulator
+  objective ball_paddle_distance
+    lesson track_ball_any_paddle
+      configure
+        constrain bricks_percent with Float32{1.0},
+        constrain level with UInt16{1:100},
+        constrain paddle_width with UInt8{1:4}
+      until
+        maximize ball_paddle_closeness
+    lesson track_ball_wide_paddle
+      configure
+        constrain bricks_percent with Float32{1.0},
+        constrain level with UInt16{1:100},
+        constrain paddle_width with UInt8{4}
+      until
+        maximize ball_paddle_closeness
+end
+```
 
-If the keyword **data** is not used the simulator or generator clause will define some schemas, which are described below.
-
-The keyword **generator** indicates that the simulator generates the training data. Generators can be thought of as a stateless simulators. They do have coded simulators but the training output does not get fed back into simulator. The generator clause has a **yield** schema that defines the training output.
-
-The keyword **simulator** indicates that the responses of the system to the training data will feed back into the training. Simulators are coded implementations of the lessons. They are time variant. A simulator coded for example in python keeps state and thus it will use deep-q learning. The simulator clause has a **state** schema that describes simulator state.
-
-### Lesson Clause (link to lesson section)
-
-The lessonClause and the assignClause are discussed in detail in their respective sections.
-
-The lessonClause contains subclauses to configure the lesson and to describe training and objective. A lesson may also include a test subclause. For more information see the section on [lessons][].
-
-The assign clause prepares the data for training. More information on the assignClause can be found in the section on [assignment][].
+One other concept which helps with playing Breakout is `keep_paddle_under_ball`.
+In the curriculum for this concept, there are two lessons. One of the lessons,
+`track_ball_any_paddle`, varies paddle width from 1 to 4. The other lesson, 
+`track_ball_wide_paddle`, has a fixed paddle width of 4. In training this
+concept, the fixed wide width paddle lesson is easier to train, and that one
+would be trained first, resulting in faster and more effective training time
+overall.  
 


### PR DESCRIPTION
Katherine's Changes:
- [x] Added all of OneNote curriculums spec to document (ignored align clause)
- [x] Restructured headings based on agreed outline
- [x] Removed links but left in placeholder brackets until headings are finalized
- [x] Left in both examples (Mountain Car from existing web and Breakout from OneNote)
- [x] Left in rules section from both web and OneNote even though it wasn't in the outline

Megan's Needed Changes:
- [x] Fix areas where Katherine had confusion (marked by bracket text)
- [x ] Prune text where OneNote + web text is overlapping (indicated by ----> from web)
- [x ] Do you want a rules section or combine it into the intro or discussion?
- [ ] Indicate where you want links to be for final PR review
- [x ] Update content as needed (if OneNote was out of date) and remove references to data and generators (and anything else not yet implemented)
- [x] Decide on which example you want to keep (Mountain Car has lots of text around it but Breakout has more complex curriculums)
- [x] Check on formatting of syntax and code

PR Review Checklist:
- [ ] Test search functionality on desktop
- [ ] Test search functionality on mobile
- [ ] Test filter functionality
- [ ] Test mobile header navigation
- [ ] Test desktop header navigation
- [ ] Test desktop homepage navigation
- [ ] Run blc http://localhost:4567/ -ro (runs broken-link-checker on whatever port you're using)
