### PR TITLE
Document updates to metrics

### DIFF
--- a/source/includes/api-reference/_api-reference.html.md
+++ b/source/includes/api-reference/_api-reference.html.md
@@ -154,6 +154,7 @@ GET /v1/{userName}/{brainName}/ws'
     "metric": "episode_value",
     "value": 34.0,
     "episode": 83,
+    "iteration": 120546,
     "concept": "balance",
     "lesson": "balancing"
 }
@@ -194,7 +195,7 @@ There are 6 types of messages that are sent on this socket: `ADD_DATA_POINT`, `P
 #### ADD_DATA_POINT
 | Parameter | Description |
 | --- | --- |
-| metric | The data series for this data, will always be `episode_value` |
+| metric | The data series for this data. This will be `episode_value` for training data points and `test_pass_value` for test data points |
 | value | The reward value for an episode |
 | episode | Which episode the value corresponds to |
 | concept | The concept the value corresponds to |

--- a/source/includes/api-reference/_api-reference.html.md
+++ b/source/includes/api-reference/_api-reference.html.md
@@ -324,8 +324,7 @@ GET /v1/{userName}/{brainName}/{version}/metrics/episode_value
 
 Test pass value contains data for test pass episodes that occur once every
 20 training episodes during training for a given version of a BRAIN.
-This represents the AI's highest reward value achieved at a regular interval
-of training.
+This value is representative of the AI’s performance at a regular interval of training.
 
 > Request
 

--- a/source/includes/api-reference/_api-reference.html.md
+++ b/source/includes/api-reference/_api-reference.html.md
@@ -322,9 +322,10 @@ GET /v1/{userName}/{brainName}/{version}/metrics/episode_value
 
 ## Test Pass Value
 
-Test pass value contains data for test passes that occur once every 20 episodes
-during training for a given version of a BRAIN.
-This represents the AI's highest reward value achieved at a given time.
+Test pass value contains data for test pass episodes that occur once every
+20 training episodes during training for a given version of a BRAIN.
+This represents the AI's highest reward value achieved at a regular interval
+of training.
 
 > Request
 
@@ -383,7 +384,7 @@ GET /v1/{userName}/{brainName}/{version}/metrics/test_pass_value
 ## Iterations
 
 Iterations contains data for the number of iterations that have occurred in a
-simulation at a given time period.
+simulation and at what timestamp. This data gets logged about once every 100 iterations.
 This can be useful for long episodes when other metrics may not be getting data.
 
 > Request

--- a/source/includes/api-reference/_api-reference.html.md
+++ b/source/includes/api-reference/_api-reference.html.md
@@ -257,11 +257,14 @@ This message has no extra data.
 
 # BRAIN Metrics
 
+The metrics endpoints will return data from BRAIN's training. They can be 
+useful for analyzing what happened during training.
 [RYAN: Small description about what these metrics are typically used for.]
 
 ## Episode Reward
 
-[For each of these have a blurb about it.]
+Episode reward contains data about each training episode.
+This represents what the AI is doing while it's learning.
 
 > Request
 
@@ -271,15 +274,78 @@ GET /v1/{userName}/{brainName}/{version}/metrics/episode_value
 
 | Parameter | Description |
 | --- | --- |
+| userName | Name of the user who has the BRAIN |
+| brainName | Name of the BRAIN |
+| version | Version of the BRAIN |
 
 ### Response
 
-[Blurb or table]
+The response will be an array of JSON of format:
 
-## Test Pass Reward
+| Parameter | Description |
+| --- | --- |
+| value | The episode's cumulative reward value |
+| episode | The episode for this value |
+| iteration | Total number of simulator iterations that have occurred |
+| time | Timestamp for when this value occurred |
+| concept| The concept this value corresponds to |
+| lesson | The lesson this value corresponds to |
+
+## Test Pass Value
+
+Test pass value contains data for test passes that occur during training.
+This represents the AI's best attempt at a given time.
+
+> Request
+
+```text
+GET /v1/{userName}/{brainName}/{version}/metrics/test_pass_value
+```
+
+| Parameter | Description |
+| --- | --- |
+| userName | Name of the user who has the BRAIN |
+| brainName | Name of the BRAIN |
+| version | Version of the BRAIN |
+
+### Response
+
+The response will be an array of JSON of format:
+
+| Parameter | Description |
+| --- | --- |
+| value | The episode's cumulative reward value |
+| episode | The test pass episode for this value |
+| iteration | Total number of simulator iterations that have occurred |
+| time | Timestamp for when this value occurred |
+| concept| The concept this value corresponds to |
+| lesson | The lesson this value corresponds to |
 
 ## Iterations
 
+Iterations contains data related to the number of simulator iterations that have occurred.
+This can be useful for long episodes when other metrics may not be getting data.
+
+> Request
+
+```text
+GET /v1/{userName}/{brainName}/{version}/metrics/iterations
+```
+
+| Parameter | Description |
+| --- | --- |
+| userName | Name of the user who has the BRAIN |
+| brainName | Name of the BRAIN |
+| version | Version of the BRAIN |
+
+### Response
+
+The response will be an array of JSON of format:
+
+| Parameter | Description |
+| --- | --- |
+| value | Total number of simulator iterations that have occurred |
+| time | Timestamp for when this value occurred |
 
 # Project Files
 

--- a/source/includes/api-reference/_api-reference.html.md
+++ b/source/includes/api-reference/_api-reference.html.md
@@ -34,6 +34,27 @@ API calls must include an Authorization header. The value of this header is your
 
 # User and BRAIN Status
 
+### BRAIN Versions
+
+BRAIN versions numerically count up each time a BRAIN is trained. There is also
+a `latest` version that can be called if desired.
+
+### BRAIN Modes
+
+BRAIN versions have the following modes:
+
+* **ready_to_train:** After Inkling is uploaded and successfully compiled, the
+BRAIN version number is incremented. That particular version is in the
+ready_to_train state. ready_to_train versions give predictions the same as or
+worse than random.
+* **training:** After the train command is given, the BRAIN version is
+incremented and that version is in the training state. In this state the user
+cannot load new Inkling into the BRAIN or restart training. The user must
+cancel training to upload new Inkling.
+* **trained:** If training is canceled or completed the BRAIN version is in
+the trained state. Trained BRAIN versions can give predictions or receive more
+training. version is NOT incremented upon training completion.
+
 ## User Status
 
 Use GET to list all BRAINs owned by the user.
@@ -188,9 +209,12 @@ GET /v1/{userName}/{brainName}/ws'
 
 ### Response
 
-The websocket will send JSON messages for events in the BRAIN. Every message will have a `type` field which can be used to determine what the rest of the payload is.
+The websocket will send JSON messages for events in the BRAIN. Every message
+will have a `type` field which can be used to determine what the rest of the payload is.
 
-There are 6 types of messages that are sent on this socket: `ADD_DATA_POINT`, `PROPERTY_CHANGED`, `CONCEPTS_SET`, `CONCEPT_CHANGED`, `FILE_UPDATED`, `FILES_UPDATED`, and `TRAINING_INITIALIZED`.
+There are 6 types of messages that are sent on this socket: `ADD_DATA_POINT`,
+`PROPERTY_CHANGED`, `CONCEPTS_SET`, `CONCEPT_CHANGED`, `FILE_UPDATED`,
+`FILES_UPDATED`, and `TRAINING_INITIALIZED`.
 
 #### ADD_DATA_POINT
 | Parameter | Description |
@@ -230,6 +254,33 @@ This message has no extra data.
 #### TRAINING_INITIALIZED
 This message has no extra data.
 
+
+# BRAIN Metrics
+
+[RYAN: Small description about what these metrics are typically used for.]
+
+## Episode Reward
+
+[For each of these have a blurb about it.]
+
+> Request
+
+```text
+GET /v1/{userName}/{brainName}/{version}/metrics/episode_value
+```
+
+| Parameter | Description |
+| --- | --- |
+
+### Response
+
+[Blurb or table]
+
+## Test Pass Reward
+
+## Iterations
+
+
 # Project Files
 
 ## Retrieve File
@@ -240,7 +291,7 @@ code in the *.ink* file for a BRAIN.
 > Request
 
 ```text
-GET /v1/{userName}/[brainName]?file={fileName}
+GET /v1/{userName}/{brainName}?file={fileName}
 ```
 
 | Parameter | Description |
@@ -261,7 +312,7 @@ BRAIN. You cannot PUT new file contents while a BRAIN is training.
 > Request
 
 ```text
-PUT /v1/{userName}/[brainName]?file={fileName}
+PUT /v1/{userName}/{brainName}?file={fileName}
 ```
 
 | Parameter | Description |
@@ -377,7 +428,9 @@ GET /v1/{userName}/{brainName}/{brainVersion}/sims/1/logs/ws
 
 ### Response
 
-The websocket will send one message for each log message (starting with the first message logged in the simulator). This websocket will automatically close when all log messages have been sent or training is complete.
+The websocket will send one message for each log message (starting with the first
+message logged in the simulator). This websocket will automatically close when
+all log messages have been sent or training is complete.
 
 ## Simulator State
 
@@ -419,7 +472,11 @@ GET, /v1/{userName}/{brainName}/{brainVersion}/sims/1/state/ws'
 
 ### Response
 
-The websocket will send JSON messages for each state transition in the simulator. The payload will have `action`, `reward`, and `state` keys. The `reward` value will be the reward the simulator gives for this state transition. The `action` will be JSON with keys which correspond to the Inkling's action schema and the `state` will be JSON with keys corresponding to the Inkling's state schema.
+The websocket will send JSON messages for each state transition in the simulator.
+The payload will have `action`, `reward`, and `state` keys. The `reward` value
+will be the reward the simulator gives for this state transition. The `action`
+will be JSON with keys which correspond to the Inkling's action schema and the
+`state` will be JSON with keys corresponding to the Inkling's state schema.
 
 # Training
 
@@ -703,30 +760,6 @@ message PredictionData {
 ```
 
 ![Prediction Message Protocol][4]
-
-
-
-# BRAIN Versions and Modes
-
-## BRAIN Versions
-
-BRAIN versions numerically count up as BRAINs are trained.
-
-## BRAIN Modes
-
-BRAIN versions have the following modes:
-
-* **ready_to_train:** After Inkling is uploaded and successfully compiled, the
-BRAIN version number is incremented. That particular version is in the
-ready_to_train state. ready_to_train versions give predictions the same as or
-worse than random.
-* **training:** After the train command is given, the BRAIN version is
-incremented and that version is in the training state. In this state the user
-cannot load new Inkling into the BRAIN or restart training. The user must
-cancel training to upload new Inkling.
-* **trained:** If training is cancelled or completes the BRAIN version is in
-the trained state. Trained BRAIN versions can give predictions or receive more
-training. version is NOT incremented upon training completion.
 
 
 [1]: https://api.bons.ai

--- a/source/includes/api-reference/_api-reference.html.md
+++ b/source/includes/api-reference/_api-reference.html.md
@@ -286,6 +286,7 @@ GET /v1/{userName}/{brainName}/{version}/metrics/episode_value
     "episode": 1,
     "lesson": "balancing",
     "value": 25,
+    "iteration": 1354,
     "concept": "balance",
     "time": "2017-11-10T06:37:11.712068096Z"
   },
@@ -293,6 +294,7 @@ GET /v1/{userName}/{brainName}/{version}/metrics/episode_value
     "episode": 2,
     "lesson": "balancing",
     "value": 43,
+    "iteration": 2784,
     "concept": "balance",
     "time": "2017-11-10T06:37:11.739321856Z"
   },
@@ -300,6 +302,7 @@ GET /v1/{userName}/{brainName}/{version}/metrics/episode_value
     "episode": 3,
     "lesson": "balancing",
     "value": 16,
+    "iteration": 4184,
     "concept": "balance",
     "time": "2017-11-10T06:37:11.769031936Z"
   }
@@ -338,7 +341,32 @@ GET /v1/{userName}/{brainName}/{version}/metrics/test_pass_value
 > Example JSON Response
 
 ```json
-   Example needed
+[
+  {
+    "episode": 1,
+    "lesson": "balancing",
+    "value": 25,
+    "iteration": 5354,
+    "concept": "balance",
+    "time": "2017-11-10T06:37:11.712068096Z"
+  },
+  {
+    "episode": 2,
+    "lesson": "balancing",
+    "value": 43,
+    "iteration": 10784,
+    "concept": "balance",
+    "time": "2017-11-10T06:37:11.739321856Z"
+  },
+  {
+    "episode": 3,
+    "lesson": "balancing",
+    "value": 16,
+    "iteration": 16184,
+    "concept": "balance",
+    "time": "2017-11-10T06:37:11.769031936Z"
+  }
+]
 ```
 
 ### Response

--- a/source/includes/api-reference/_api-reference.html.md
+++ b/source/includes/api-reference/_api-reference.html.md
@@ -257,14 +257,14 @@ This message has no extra data.
 
 # BRAIN Metrics
 
-The metrics endpoints will return data from BRAIN's training. They can be 
-useful for analyzing what happened during training.
-[RYAN: Small description about what these metrics are typically used for.]
+The metrics endpoints will return data from the specified version of a BRAIN's
+training. They can be useful for analyzing what happened during training.
 
-## Episode Reward
+## Episode Value
 
-Episode reward contains data about each training episode.
-This represents what the AI is doing while it's learning.
+Episode value contains data about each training episode for a given version of a BRAIN.
+This represents what the AI has been rewarded and what it's currently learning
+through simulation.
 
 > Request
 
@@ -278,9 +278,35 @@ GET /v1/{userName}/{brainName}/{version}/metrics/episode_value
 | brainName | Name of the BRAIN |
 | version | Version of the BRAIN |
 
-### Response
+> Example JSON Response
 
-The response will be an array of JSON of format:
+```json
+[
+  {
+    "episode": 1,
+    "lesson": "balancing",
+    "value": 25,
+    "concept": "balance",
+    "time": "2017-11-10T06:37:11.712068096Z"
+  },
+  {
+    "episode": 2,
+    "lesson": "balancing",
+    "value": 43,
+    "concept": "balance",
+    "time": "2017-11-10T06:37:11.739321856Z"
+  },
+  {
+    "episode": 3,
+    "lesson": "balancing",
+    "value": 16,
+    "concept": "balance",
+    "time": "2017-11-10T06:37:11.769031936Z"
+  }
+]
+```
+
+### Response
 
 | Parameter | Description |
 | --- | --- |
@@ -293,8 +319,9 @@ The response will be an array of JSON of format:
 
 ## Test Pass Value
 
-Test pass value contains data for test passes that occur during training.
-This represents the AI's best attempt at a given time.
+Test pass value contains data for test passes that occur once every 20 episodes
+during training for a given version of a BRAIN.
+This represents the AI's highest reward value achieved at a given time.
 
 > Request
 
@@ -308,9 +335,13 @@ GET /v1/{userName}/{brainName}/{version}/metrics/test_pass_value
 | brainName | Name of the BRAIN |
 | version | Version of the BRAIN |
 
-### Response
+> Example JSON Response
 
-The response will be an array of JSON of format:
+```json
+   Example needed
+```
+
+### Response
 
 | Parameter | Description |
 | --- | --- |
@@ -323,7 +354,8 @@ The response will be an array of JSON of format:
 
 ## Iterations
 
-Iterations contains data related to the number of simulator iterations that have occurred.
+Iterations contains data for the number of iterations that have occurred in a
+simulation at a given time period.
 This can be useful for long episodes when other metrics may not be getting data.
 
 > Request
@@ -338,14 +370,36 @@ GET /v1/{userName}/{brainName}/{version}/metrics/iterations
 | brainName | Name of the BRAIN |
 | version | Version of the BRAIN |
 
-### Response
+> Example JSON Response
 
-The response will be an array of JSON of format:
+```json
+[
+  {
+    "value": 134,
+    "time": "2017-08-22T19:40:47.631161088Z"
+  },
+  {
+    "value": 267,
+    "time": "2017-08-22T19:40:48.393937152Z"
+  },
+  {
+    "value": 374,
+    "time": "2017-08-22T19:40:49.018401024Z"
+  },
+  {
+    "value": 503,
+    "time": "2017-08-22T19:40:49.508259072Z"
+  }
+]
+```
+
+### Response
 
 | Parameter | Description |
 | --- | --- |
 | value | Total number of simulator iterations that have occurred |
 | time | Timestamp for when this value occurred |
+
 
 # Project Files
 


### PR DESCRIPTION
This is what will change for the new graph. I didn't see a place for documenting the HTTP `/metrics` endpoint, if that's valuable lmk

!!!!! STOP AND READ !!!!!

If the dropdown above says "base fork: lord/master", click "base fork" to change it to the bonsaiai.github.io on the dev branch, *NOT master branch*.

PR Review Checklist:
- [x] Test search functionality on desktop
- [x] Test search functionality on mobile
- [x] Test filter functionality
- [x] Test mobile header navigation
- [x] Test desktop header navigation
- [x] Test desktop homepage navigation
- [ ] Run blc http://localhost:4567/ -ro (runs broken-link-checker on whatever port you're using)
