### PR TITLE
Fix tablet and half screen laptop menu render.

### DIFF
--- a/source/stylesheets/_variables.scss
+++ b/source/stylesheets/_variables.scss
@@ -62,7 +62,7 @@ $nav-v-padding: 10px !default; // padding used vertically around search boxes an
 $nav-indent: 1em !default; // extra padding for ToC subitems
 $code-annotation-padding: 13px !default; // padding inside code annotations
 $h1-margin-bottom: 21px !default; // padding under the largest header tags
-$tablet-width: 930px !default; // min width before reverting to tablet size
+$tablet-width: 1000px !default; // min width before reverting to tablet size
 $phone-width: $tablet-width - $nav-width !default; // min width before reverting to mobile size
 
 

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -926,7 +926,7 @@ nav ul li ul li a {
   width: 70px;
 }
 
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: $tablet-width) {
 	
 	
 	nav ul li ul li a {
@@ -1018,7 +1018,7 @@ nav ul li ul li a {
   height: initial;
   }
 }
-@media screen and (min-width: 1000px) {
+@media screen and (min-width: $tablet-width) {
 	
 	 #primary-nav .selected a {border-bottom: solid 4px #3bb94f;padding-bottom: 12px;margin-top: 18px;}
 
@@ -1320,7 +1320,7 @@ nav li > a:only-child:after {content: '';}
 /* Media Queries
 --------------------------------------------- */
 
-@media all and (max-width : 1000px) {
+@media all and (max-width : $tablet-width) {
 
 	.menu-ham {width:26px;padding-right: 20px;}
 #primary-nav  ul li ul li a {margin-right:0!important;background-color: hsl(52, 48%, 94%);}
@@ -1459,7 +1459,7 @@ nav li > a:only-child:after {content: '';}
 
 /*mobile slider*/
 
-@media screen and (max-width: 1000px) {
+@media screen and (max-width: $tablet-width) {
 
 	.tocify-wrapper.open {
 	    top: 0 !important;

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -926,7 +926,7 @@ nav ul li ul li a {
   width: 70px;
 }
 
-@media only screen and (max-width: 870px) {
+@media only screen and (max-width: 1000px) {
 	
 	
 	nav ul li ul li a {
@@ -1320,7 +1320,7 @@ nav li > a:only-child:after {content: '';}
 /* Media Queries
 --------------------------------------------- */
 
-@media all and (max-width : 870px) {
+@media all and (max-width : 1000px) {
 
 	.menu-ham {width:26px;padding-right: 20px;}
 #primary-nav  ul li ul li a {margin-right:0!important;background-color: hsl(52, 48%, 94%);}
@@ -1459,7 +1459,7 @@ nav li > a:only-child:after {content: '';}
 
 /*mobile slider*/
 
-@media screen and (max-width: 870px) {
+@media screen and (max-width: 1000px) {
 
 	.tocify-wrapper.open {
 	    top: 0 !important;


### PR DESCRIPTION
This might not be the ideal fix but it works to have everything render as mobile view once you get smaller than 1000px. Anything smaller than this and the current menu options run into the logo.

PR Review Checklist:
- [x] Test search functionality on desktop
- [x] Test search functionality on mobile
- [x] Test filter functionality
- [x] Test mobile header navigation
- [x] Test desktop header navigation
- [x] Test desktop homepage navigation
- [x] Run blc http://localhost:4567/ -ro (runs broken-link-checker on whatever port you're using)
