### PR TITLE
Fix for JS errors on home page

### DIFF
--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -46,9 +46,8 @@
   }
 
   $(function() {
-    setupLanguages($('body').data('languages'));
-
     makeToc();
+    setupLanguages($('body').data('languages'));
     if (global.toc) {
       animate();
       $('.content').imagesLoaded( function() {

--- a/source/javascripts/app/_toc.js
+++ b/source/javascripts/app/_toc.js
@@ -46,11 +46,14 @@
   }
 
   $(function() {
-    makeToc();
-    animate();
     setupLanguages($('body').data('languages'));
-    $('.content').imagesLoaded( function() {
-      global.toc.calculateHeights();
-    });
+
+    makeToc();
+    if (global.toc) {
+      animate();
+      $('.content').imagesLoaded( function() {
+        global.toc.calculateHeights();
+      });
+    }
   });
 })(window);


### PR DESCRIPTION
There's some code that runs on the home page assuming the table of contents is around, I'm just adding an if to not run that code if the table of contents isn't around..

Gets rid of:
- Uncaught TypeError: Cannot read property 'setOption' of undefined
- Uncaught TypeError: Cannot read property 'calculateHeights' of undefined

!!!!! STOP AND READ !!!!!

If the dropdown above says "base fork: lord/master", click "base fork" to change it to the bonsaiai.github.io on the `dev` branch, *NOT `master` branch*.

PR Review Checklist:
- [ ] Test search functionality on desktop
- [ ] Test search functionality on mobile
- [ ] Test filter functionality
- [ ] Test mobile header navigation
- [ ] Test desktop header navigation
- [ ] Test desktop homepage navigation
- [ ] Run `npm run check-links` with 0 broken links
- [ ] Run `npm run write-good <files being edited>` to "lint" the docs
