### PR TITLE
Only include mixpanel in production

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -1,5 +1,5 @@
 
-#Helpers 
+#Helpers
 helpers do
   def is_page_selected(page)
     current_page.url == page ? "selected" : ''
@@ -47,6 +47,7 @@ configure :build do
   # out the following two lines has been known to help
   activate :minify_css
   activate :minify_javascript
+  set :app_config, 'production'
   # activate :relative_assets
   # activate :asset_hash
   # activate :gzip
@@ -60,6 +61,6 @@ set :port, 4567
 # Navigation gem
 
 #activate :navigation
-# 
+#
 # SASS
  sass_options = { :debug_info => true }

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -23,7 +23,9 @@
 	<%= javascript_include_tag  "all_nosearch" %>
 	<% end %>
 	<%= partial "partials/google-gtm" %>
-	<%= partial "partials/mixpanel" %>
+	<% if config[:app_config] == 'production' %>
+		<%= partial "partials/mixpanel" %>
+	<% end %>
 </head>
 
 <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -24,7 +24,9 @@
     <% end %>
 
     <%= partial "partials/google-gtm" %>
-    <%= partial "partials/mixpanel" %>
+    <% if config[:app_config] == 'production' %>
+      <%= partial "partials/mixpanel" %>
+    <% end %>
   </head>
 
   <body class="<%= page_classes %>" data-languages="<%=h language_tabs.map{ |lang| lang.is_a?(Hash) ? lang.keys.first : lang }.to_json %>">


### PR DESCRIPTION
Adds a built setting `app_config` we check against in the layouts...

Verified by checking the code wasn't included in dev, running `bundle exec middleman build` and looking at the output HTML files, which do include our code... You may want to include the other marketing code inside this if :)

!!!!! STOP AND READ !!!!!

If the dropdown above says "base fork: lord/master", click "base fork" to change it to the bonsaiai.github.io on the `dev` branch, *NOT `master` branch*.

PR Review Checklist:
- [ ] Test search functionality on desktop
- [ ] Test search functionality on mobile
- [ ] Test filter functionality
- [ ] Test mobile header navigation
- [ ] Test desktop header navigation
- [ ] Test desktop homepage navigation
- [ ] Run `npm run check-links` with 0 broken links
- [ ] Run `npm run write-good <files being edited>` to "lint" the docs
