### PR TITLE
Create Release Notes Page

### DIFF
--- a/source/includes/_release-notes.html.md
+++ b/source/includes/_release-notes.html.md
@@ -1,0 +1,77 @@
+# Product Release Notes
+
+These release notes combine releases for the web (BRAIN Dashboard), the backend services (Bonsai AI Engine), and Bonsai's API. All releases are tagged by date for the web, backend, and API. Releases are based on version for the SDKs and CLI which are available on GitHub.
+
+Release Notes for CLI: [https://github.com/BonsaiAI/bonsai-cli/blob/master/CHANGELOG.md]()
+
+Release Notes for Python SDK (bonsai-ai): [https://github.com/BonsaiAI/bonsai-sdk/blob/master/bonsai-ai/CHANGELOG.md]()
+
+### 2018.02.23
+
+Various bug fixes, including:
+
+* Fix for concept threshold termination tags not terminating as expected
+* Removed limitation for Inkling variables ending in underscore followed by a number
+* Fixed backend race conditions causing dropped simulators
+
+### 2018.02.13
+
+Notable features:
+
+* You can now Resume Training a BRAIN or Restart Training instead
+* Tags for reward and iteration based termination of concepts
+
+Various bug fixes, including:
+
+* Fixed action scaling in prediction episodes being different than training episodes
+* Fix for the iteration and exploration rate update for resume training
+
+### 2018.02.08
+
+Notable features:
+
+* Python SDK2 simulators can now run hosted on the web
+* Resource limits have now been added to containers
+
+Various bug fixes, including:
+
+* Fixed IE11 visual display issues
+* Fixed color caching issue requiring hard restart
+
+### 2018.02.02
+
+Notable features:
+
+* Support of IE11 (Windows 7 and Windows 10)
+* Python SDK2 standalone support (not linked against C++ binaries)
+* Beta CPU and GPU node capacity has been tripled
+
+Various bug fixes, including:
+
+* Some BRAINs in Training were listed as Not Started while in Progress
+* Fixed bonsai-ai not working for Python 3.5 on OSX
+* Fix for IE11 not displaying access keys
+
+### 2018.01.23
+
+Notable features:
+
+* New color scheme for BRAIN web graphs
+
+Various bug fixes, including:
+
+* Fix for IE11 BRAIN Dashboard
+* Fixed occasional application error when trying to stop BRAIN training
+
+### 2018.01.18
+
+Notable features:
+
+* BRAINs on beta are now private
+
+Various bug fixes, including:
+
+* Connecting a simulator for prediction will no longer alter the BRAIN's status
+* Fixed issue where training graph would overlap older and newer training sessions
+* Fix for bonsai push command not correctly uploading files to beta portal
+

--- a/source/includes/_release-notes.html.md
+++ b/source/includes/_release-notes.html.md
@@ -1,16 +1,21 @@
 # Product Release Notes
 
-These release notes combine releases for the web (BRAIN Dashboard), the backend services (Bonsai AI Engine), and Bonsai's API. All releases are tagged by date for the web, backend, and API. Releases are based on version for the SDKs and CLI which are available on GitHub.
+These release notes combine releases for the web (BRAIN Dashboard), the backend services (Bonsai AI Engine), and Bonsai's API. All releases are tagged by date for the web, backend, and API. SDK and CLI are released separately and have different version numbers. They are available on GitHub.
 
 Release Notes for CLI: [https://github.com/BonsaiAI/bonsai-cli/blob/master/CHANGELOG.md]()
 
-Release Notes for Python SDK (bonsai-ai): [https://github.com/BonsaiAI/bonsai-sdk/blob/master/bonsai-ai/CHANGELOG.md]()
+Release Notes for Python SDK (bonsai-ai, bonsai-cli, and bonsai-gym libraries): [https://github.com/BonsaiAI/bonsai-sdk/blob/master/bonsai-ai/CHANGELOG.md]()
+
+### 2018.03.07
+
+Various bug fixes, including:
+
+* Fixes for resume training
 
 ### 2018.02.23
 
 Various bug fixes, including:
 
-* Fix for concept threshold termination tags not terminating as expected
 * Removed limitation for Inkling variables ending in underscore followed by a number
 * Fixed backend race conditions causing dropped simulators
 
@@ -19,7 +24,6 @@ Various bug fixes, including:
 Notable features:
 
 * You can now Resume Training a BRAIN or Restart Training instead
-* Tags for reward and iteration based termination of concepts
 
 Various bug fixes, including:
 

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -185,6 +185,7 @@
 						<a href="https://beta.bons.ai">BRAIN Dashboard</a>
 						<a href="http://pages.bons.ai/apply.html">Apply for Bonsai Platform Preview</a>
 						<a href="https://github.com/BonsaiAI/slate">Contribute to the Docs on GitHub</a>
+						<a href="/releases.html">Product Release Notes</a>
 
 
 						<a class="home-cc-icon" href='https://creativecommons.org/licenses/by-sa/4.0/'>

--- a/source/partials/_footer-links.erb
+++ b/source/partials/_footer-links.erb
@@ -5,6 +5,7 @@
 <li><a href='https://beta.bons.ai'>BRAIN Dashboard</a></li>
 <li><a href='https://github.com/BonsaiAI/slate'>Contribute to the Docs</a></li>
 <li><a href='http://pages.bons.ai/apply.html'>Apply for Bonsai Platform Preview</a></li>
+<li><a href="/releases.html">Product Release Notes</a></li>
 <li><a href='https://bons.ai/contact-us#contact-page-form'>Contact Us</a></li>
 
 </ul>

--- a/source/releases.html.md
+++ b/source/releases.html.md
@@ -1,0 +1,11 @@
+---
+title: Releases
+
+toc_footers:
+  -  <%= partial "partials/footer-links" %>
+
+includes:
+- release-notes.html.md
+
+search: true
+---


### PR DESCRIPTION
Added a new release notes page and linked to it from the footer on each page and the homepage. The plan for this page is to be manually updated from the internal release notes page that Shane provides internally.

@srainier please make sure that all of the current notes I have taken from the internal notes are relevant to an external audience and able to be shared.

PR Review Checklist:
- [x] Test search functionality on desktop
- [x] Test search functionality on mobile
- [x] Test filter functionality
- [x] Test mobile header navigation
- [x] Test desktop header navigation
- [x] Test desktop homepage navigation
- [ ] Run `npm run check-links` with 0 broken links
- [ ] Run `npm run write-good <files being edited>` to "lint" the docs
