### PR TITLE
Split the Library Reference into Python and C++

### DIFF
--- a/source/includes/cpp-library-reference/_brain.html.md
+++ b/source/includes/cpp-library-reference/_brain.html.md
@@ -12,7 +12,7 @@ Brain() >> --brain >> .brains >> .bonsai[profile] >> .bonsai[DEFAULT] >> env[BON
 such that ">>" indicates a decreasing order of precedence. Note that failure to set
 BRAIN name in at least one of these places will result in a friendly error.
 
-## Brain(config, name)
+## `Brain(config, name)`
 
 ```cpp
 auto config = make_shared<bonsai::Config>(argc, argv);

--- a/source/includes/cpp-library-reference/_brain.html.md
+++ b/source/includes/cpp-library-reference/_brain.html.md
@@ -14,65 +14,74 @@ BRAIN name in at least one of these places will result in a friendly error.
 
 ## Brain(config, name)
 
-```python
-config = bonsai_ai.Config(sys.argv)
-brain = bonsai_ai.Brain(config)
-print(brain)
+```cpp
+auto config = make_shared<bonsai::Config>(argc, argv);
+auto brain = make_shared<bonsai::Brain>(config);
+std::cout << brain << std::endl;
 ```
 
 Creates a local object for interacting with an existing BRAIN on the server.
 
 | Argument | Description |
 | ---      | ---         |
-| `config` | Object returned by previously created `bonsai_ai.Config()`. |
+| `config` | Object returned by previously created `Bonsai::Config`. |
 | `name`   | BRAIN name as specified on the server. If name is empty, the BRAIN name in `config` is used instead. |
 
 ## update()
 
-```python
-brain.update()
+```cpp
+brain.update();
 ```
 
 Refreshes description, status, and other information with the current state of the BRAIN on the server.
 Called by default when constructing a new Brain object.
 
-## name()
+## string name()
 
-```python
-print(brain.name)
+```cpp
+std::cout << brain.name() << endl;
 ```
 
 Returns the name of the BRAIN as specified when it was created.
 
-## description()
+## string description()
 
-```python
-print(brain.description)
+```cpp
+std::cout << brain.description() << endl;
 ```
 
 Returns the user-provided description for the BRAIN.
 
-## version()
+## int version()
 
-```python
-print(brain.version)
+```cpp
+std::cout << brain.version() << endl;
 ```
 
 Returns the current version number of the BRAIN.
 
-## latest_version()
+## int latest_version()
 
-```python
-print(brain.latest_version)
+```cpp
+std::cout << brain.latest_version() << endl;
 ```
 
 Returns latest version number of the BRAIN.
 
 ## Config config()
 
-```python
-print(brain.config)
+```cpp
+std::cout << brain.config() << endl;
 ```
 
 Returns the configuration used to locate this BRAIN.
+
+## operator<<(ostream, brain)
+
+Prints out a representation of Brain that is useful for debugging.
+
+| Argument  | Description |
+| ---       | ---         |
+| `ostream` | A std C++ stream operator. |
+| `brain`   | A `bonsai::Brain` object to print out. |
 

--- a/source/includes/cpp-library-reference/_brain.html.md
+++ b/source/includes/cpp-library-reference/_brain.html.md
@@ -12,7 +12,7 @@ Brain() >> --brain >> .brains >> .bonsai[profile] >> .bonsai[DEFAULT] >> env[BON
 such that ">>" indicates a decreasing order of precedence. Note that failure to set
 BRAIN name in at least one of these places will result in a friendly error.
 
-## `Brain(config, name)`
+## Brain(config, name)
 
 ```cpp
 auto config = make_shared<bonsai::Config>(argc, argv);

--- a/source/includes/cpp-library-reference/_config.html.md
+++ b/source/includes/cpp-library-reference/_config.html.md
@@ -24,11 +24,12 @@ one configuration file.
 
 ## Config(profile)
 
-```python
-import sys, bonsai_ai
-if __name__ == "__main__":
-    config = bonsai_ai.Config()
-    print(config)
+```cpp
+#include <bonsai.hpp>
+int main(int argc, char** argv) {
+    auto config = bonsai::Config();
+    std::cout << config << std::endl;
+}
 ```
 
 Constructs a default configuration.
@@ -40,13 +41,14 @@ Constructs a default configuration.
 Configurations are stored in `~/.bonsai` and `./.bonsai` configuration files.
 The local configuration file overrides settings in the configuration file in the user home directory.
 
-## Config(argv, profile)
+## Config(argc, argv, profile)
 
-```python
-import sys, bonsai_ai
-if __name__ == "__main__":
-    config = bonsai_ai.Config(sys.argv)
-    print(config)
+```cpp
+#include <bonsai.hpp>
+int main(int argc, char** argv) {
+    auto config = bonsai::Config(argc, argv);
+    std::cout << config << std::endl;
+}
 ```
 
 Constructs a config by looking in the configuration files and parsing the command line arguments.
@@ -54,16 +56,17 @@ To see the list of command line arguments, pass in the `--help` flag.
 
 | Argument  | Description |
 | ---       | ---         |
-| `argv`    | As passed to main(). |
+| `argc`    | As passed to main(). (C++)|
+| `argv`    | As passed to main(). (C++/Python)|
 | `profile` | Optional `.bonsai` profile name. Will use the DEFAULT profile if not specified. |
 
 Unrecognized arguments will be ignored.
 
 ## accesskey()
 
-```python
-my_config.accesskey == '00000000-1111-2222-3333-000000000001'
-my_config.accesskey = '00000000-1111-2222-3333-000000000001'
+```cpp
+my_config.accesskey() == "00000000-1111-2222-3333-000000000001";
+my_config.set_accesskey("00000000-1111-2222-3333-000000000001");
 ```
 
 Server authentication token.
@@ -71,9 +74,9 @@ Obtained from the bonsai server. You need to set it in your config.
 
 ## username()
 
-```python
-my_config.username == 'alice'
-my_config.username = 'alice'
+```cpp
+my_config.username() == "alice";
+my_config.set_username("alice");
 ```
 
 Account user name.
@@ -81,9 +84,9 @@ The account you signed up with.
 
 ## url()
 
-```python
-my_config.url == 'https://api.bons.ai'
-my_config.url = 'https://api.bons.ai'
+```cpp
+my_config.url() == "https://api.bons.ai";
+my_config.set_url("https://api.bons.ai");
 ```
 
 Server URL.
@@ -91,9 +94,9 @@ Address and port number of the bonsai server. Normally you should not need to ch
 
 ## proxy()
 
-```python
-my_config.proxy == 'myproxy:5000'
-my_config.proxy = 'myproxy:5000'
+```cpp
+my_config.proxy() == "myproxy:5000";
+my_config.set_proxy("myproxy:5000");
 ```
 
 Proxy Server.
@@ -101,9 +104,9 @@ Address and port number of the proxy server to connect through.
 
 ## brain()
 
-```python
-my_config.brain == 'scarecrow'
-my_config.brain = 'scarecrow'
+```cpp
+my_config.brain() == "scarecrow";
+my_config.set_brain("scarecrow");
 ```
 
 BRAIN name.
@@ -111,9 +114,9 @@ Name of the BRAIN on the server.
 
 ## predict()
 
-```python
-my_config.predict == True
-my_config.brain = True
+```cpp
+my_config.predict() == true;
+my_config.set_predict(true);
 ```
 
 Simulator mode.
@@ -121,9 +124,9 @@ The mode in which simulators will run. True if running for prediction, false for
 
 ## brain_version()
 
-```python
-my_config.brain_version == 0
-my_config.brain_version = 0
+```cpp
+my_config.brain_version() == 0;
+my_config.set_brain_version(0);
 ```
 
 BRAIN version.
@@ -131,25 +134,35 @@ The version of the brain to use when running for prediction. Set to 0 to use lat
 
 ## record_file()
 
-```python
-my_config.record_file == "foobar.json"
-my_config.record_file = "foobar.json"
+```cpp
+my_config.record_file() == "foobar.json";
+my_config.set_record_file("foobar.json");
 ```
 
 This property defines the destination for log recording. Additionally, the format for log recording is inferred from the file extension. Currently supported options are `json` and `csv`. Missing file extension or use of an unsupported extension will result in runtime errors.
 
 ## record_enabled()
 
-```python
-my_config.record_enabled == True
-my_config.record_enabled = True
+```cpp
+my_config.record_enabled() == true;
+my_config.set_record_enabled(true);
 ```
 
 ## record_format()
 
-```python
-my_config.record_file == "foobar.json"
-my_config.record_format == "json";
+```cpp
+my_config.record_file() == "foobar.json";
+my_config.record_format() == "json";
 ```
 
 **Note:** This property cannot be set directly. It reflects the file extension of the currently configured `record_file`. `json` or `csv` are valid.
+
+## operator<<(ostream, config)
+
+Will print out a representation of Config that is useful for debugging.
+
+| Argument  | Description |
+| ---       | ---         |
+| `ostream` | A std c++ stream operator. |
+| `config`  | A `bonsai::Config` object to print. |
+

--- a/source/includes/cpp-library-reference/_event.html.md
+++ b/source/includes/cpp-library-reference/_event.html.md
@@ -1,7 +1,10 @@
 # Event Class
 
-Abstract base class for encapsulating Simulator state. Event types correspond to different
-procedures in client code (see `enum class Type`).
+Internally, the Bonsai library uses a state machine to drive activity in user code (i.e. advancing and recording simulator state, resetting a simulator, etc). State transfer is driven primarily by a websocket-based messaging protocol shared between the library and the Bonsai AI platform. For your convenience, the details of this protocol have been hidden behind a pair of API's, one based on callbacks in `bonsai_ai.Simulator` and the other event driven.
+
+Filling out the callbacks in `bonsai_ai.Simulator` and relying on `Simulator.run` to invoke them at the appropriate time will be sufficient for many use cases. For example, if you have a simulator which can be advanced, reset, and observed in a synchronous manner from Python or C++ code, your application is likely amenable to our callback API. However, if, for example, your simulator is free running and communicates with your application code asynchronously, your application will likely need to employ the event driven API described below.
+
+In the **event-driven mode of operation**, you application code should implement its own run loop by requesting successive events from the Bonsai library and handling them in a way that is appropriate to your particular simulation or deployment architecture. For example, if your simulator invokes callbacks into your code and is reset in response to some outgoing signal (i.e. not via a method call), you might respond to an `EpisodeStartEvent` by setting the appropriate flag, returning control to the simulator, and returning the resulting state to the Bonsai platform the next time your callback gets invoked.
 
 ### enum class Type
 
@@ -24,6 +27,9 @@ if (event->type() == Type::Episode_Start) {
 }
 ```
 
+Event is an abstract base class for encapsulating Simulator state. Event types correspond to different
+procedures in client code as shown in the table below.
+
 | Value          | Description |
 | ----           | ----        |
 | `Episode_Start`|  Reset the simulator and set initial state. |
@@ -44,7 +50,7 @@ Settings used when resetting the simulation environment.
 ###### std::shared_ptr<InklingMessage> initial_state
 Directly manipulate to reflect the state resulting from sim environment reset.
 
-See `InklingMessage` API for detail.
+See `InklingMessage` header for details.
 
 ## SimulateEvent Class
 Signals that the **BRAIN** is ready to receive the simulator state resulting from
@@ -57,7 +63,7 @@ The prediction (action) intended for the next simulation step.
 Directly manipulate to reflect the state resulting from applying `prediction`
 to the simulation environment.
 
-See `InklingMessage` API for detail.
+See `InklingMessage` header for details.
 
 ###### std::shared_ptr<float> reward
 Directly manipulate to reflect the reward corresponding to `state`.

--- a/source/includes/cpp-library-reference/_event.html.md
+++ b/source/includes/cpp-library-reference/_event.html.md
@@ -1,0 +1,73 @@
+# Event Class
+
+Abstract base class for encapsulating Simulator state. Event types correspond to different
+procedures in client code (see `enum class Type`).
+
+### enum class Type
+
+```cpp
+auto event = get_next_event();
+if (event->type() == Type::Episode_Start) {
+    auto es_E = dynamic_pointer_cast<EpisodeStartEvent>(event);
+    auto initial_properties = es_E->initial_properties;
+    auto initial_state = es_E->initial_state;
+    // process initial properties/state
+} else if (event->type() == Type::Simulate) {
+    auto sim_E = dynamic_pointer_cast<SimulatorEvent>(event);
+    auto prediction = sim_E->prediction;
+    auto state = sim_E->state;
+    auto reward = sim_E->reward;
+    auto terminal = sim_E->terminal;
+    // process simulator step 
+} else if (event->type() == Type::Finished) {
+    close();
+}
+```
+
+| Value          | Description |
+| ----           | ----        |
+| `Episode_Start`|  Reset the simulator and set initial state. |
+| `Simulate`     |  Advance the simulation with the next prediction and record resulting state. |
+| `Finished`     |  Simulation complete. BRAIN does not expect further state data. |
+| `Unknown`      |  No event corresponding to last message exchange. |
+
+### Type type()
+Returns the Type of the Event. Implemented for each specialization of Event.
+
+## EpisodeStartEvent Class
+Signals a boundary between training episodes. Requires resetting the simulation environment
+and returning its initial state to the **BRAIN**.
+
+###### std::shared_ptr<const InklingMessage> initial_properties
+Settings used when resetting the simulation environment.
+
+###### std::shared_ptr<InklingMessage> initial_state
+Directly manipulate to reflect the state resulting from sim environment reset.
+
+See `InklingMessage` API for detail.
+
+## SimulateEvent Class
+Signals that the **BRAIN** is ready to receive the simulator state resulting from
+the next prediction in the queue.
+
+###### std::shared_ptr<const InklingMessage> prediction
+The prediction (action) intended for the next simulation step.
+
+###### std::shared_ptr<InklingMessage> state
+Directly manipulate to reflect the state resulting from applying `prediction`
+to the simulation environment.
+
+See `InklingMessage` API for detail.
+
+###### std::shared_ptr<float> reward
+Directly manipulate to reflect the reward corresponding to `state`.
+
+###### std::shared_ptr<bool> terminal
+Directly manipulate to reflect whether the current `state` is terminal.
+
+## FinishedEvent Class
+Signals that the **BRAIN** is done training. No more simulation steps are expected.
+
+## UnknownEvent Class
+Signals that no action is required.
+

--- a/source/includes/cpp-library-reference/_introduction.html.md
+++ b/source/includes/cpp-library-reference/_introduction.html.md
@@ -1,6 +1,6 @@
 # Library Overview
 
-The Bonsai libraries known as `libbonsai` (C++) and `bonsai_ai` (Python) wrap the Bonsai API to simplify the process of building simulators in C++ and Python programming languages. This Python library is compatible with Python 2.7+ and Python 3+ on Windows 7/10, macOS, and Linux.
+The Bonsai libraries known as `libbonsai` (C++) and `bonsai_ai` (Python) wrap the Bonsai API to simplify the process of building simulators in C++ and Python programming languages. The C++ library is current in beta and not 100% on feature parity with the Python library. This library is compatible with Windows 7/10, macOS, and Linux.
 
 When the AI Engine trains with the simulator it works in a loop. First, the simulator connects and registers itself with the AI Engine. Then, the simulator sends the AI Engine a state and the value of any objectives or rewards; next, the AI Engine replies with an action. The simulator then uses this action to advance the simulation and compute a new state. This “send state, receive action” process is repeated until training stops. At any time the AI engine may stop, reconfigure, and reset the simulator. After doing so it will either restart this training loop or stop training. A single state, action, next state, loop is sometimes referred to as an “iteration”.
 

--- a/source/includes/cpp-library-reference/_logger.html.md
+++ b/source/includes/cpp-library-reference/_logger.html.md
@@ -1,0 +1,98 @@
+# Logging Class
+
+Runtime logging is accomplished using the `BONSAI_LOG` macro, which `BONSAI_LOG` may be invoked
+freely on log domains of your choosing, but the accompanying messages will only be printed if
+a given domain has been enabled either through command line flags (see `bonsai::Config`) or
+through `bonsai::logging::set_enabled`.
+
+Consumers of `bonsai::logging` may enable a custom handler for `BONSAI_LOG` via
+`logging::set_handler`. By default, logs print to `stderr`.
+
+Additionally, use `logging::set_use_colors` to enable/disable ASCII colors in log output.
+
+```cpp
+using bonsai::logging;
+
+class MySimulator : public Simulator {
+...
+    void simulate(const bonsai::InklingMessage& action,
+                   bonsai::InklingMessage& state,
+                   float& reward, bool& terminal) {
+        ...
+        BONSAI_LOG(foobar, "things (" << reward << ") stuff"); // logged
+        BONSAI_LOG(barfoo, "things (" << reward << ") stuff"); // not logged
+        ...
+    }
+...
+};
+int main() {
+    ...
+    logging::log().set_enabled(true)
+    logging::log().set_enabled("foobar")
+    ...
+}
+```
+
+## BONSAI_LOG(domain, message)
+
+`BONSAI_LOG` is a preprocessor macro defined in `logging.hpp`. It encapsulates various calls into
+the `logging` singleton and performs the necessary domain checks and I/O procedures without the
+overhead of an additional function call.
+
+```cpp
+void MySimulator::simulate() {
+    ...
+    BONSAI_LOG(foobar, "my hovercraft has " << val << "eels");
+    ...
+}
+```
+
+The log domain should not include quotes. It will be quoted into a string literal at preprocessor time.
+
+Similarly, the message will be interpolated into an expression of the form `std::cerr << X << std::endl;`. As such, `message` can be any expression which produces syntactically correct C++  when substituted for X in an expression of that form.
+
+## enabled()
+
+Global switch to enable/disable logging.
+
+```cpp
+bonsai::logging::log().enabled() == false;
+bonsai::logging::log().set_enabled(true);
+```
+
+Individual switches to enable/disable specific domains.
+
+```cpp
+bonsai::logging::log().enabled("foobar") == false;
+bonsai::logging::log().set_enabled("foobar");
+```
+
+## enabled_all()
+
+```cpp
+bonsai::logging::log().enabled_all() == true;
+bonsai::logging::log().set_enable_all(true);
+```
+
+Switch to enable/disable verbose logging.
+
+## use_colors
+
+```cpp
+bonsai::logging::log().use_colors() == true;
+bonsai::logging::log().set_use_colors(false);
+```
+
+Switch to enable/disable ASCII colors in log output. Enabled by default.
+
+## set_handler(function\<void(stringstream&)\>)
+
+```cpp
+bonsai::logging::log().set_handler([](std::stringstream& ss) {
+    printf("%s", ss.str().c_str());
+});
+```
+
+Set a custom handler for `BONSAI_LOG`. Instead of streaming directly to 
+`std::cerr`, each log line will be passed to this custom handler in the form of a `std::stringstream`.
+

--- a/source/includes/cpp-library-reference/_logger.html.md
+++ b/source/includes/cpp-library-reference/_logger.html.md
@@ -1,6 +1,6 @@
 # Logging Class
 
-Runtime logging is accomplished using the `BONSAI_LOG` macro, which `BONSAI_LOG` may be invoked
+Runtime logging is accomplished using the `BONSAI_LOG` macro; `BONSAI_LOG` may be invoked
 freely on log domains of your choosing, but the accompanying messages will only be printed if
 a given domain has been enabled either through command line flags (see `bonsai::Config`) or
 through `bonsai::logging::set_enabled`.
@@ -76,7 +76,7 @@ bonsai::logging::log().set_enable_all(true);
 
 Switch to enable/disable verbose logging.
 
-## use_colors
+## use_colors()
 
 ```cpp
 bonsai::logging::log().use_colors() == true;

--- a/source/includes/cpp-library-reference/_simulator.html.md
+++ b/source/includes/cpp-library-reference/_simulator.html.md
@@ -15,8 +15,8 @@ demonstrates how these are called during training. Optionally, one may also over
 
 | Property          | Description |
 | ---               | ---         |
-| `brain`           |  The simulator's Brain object. |
-| `name`            |  The simulator's name. |
+| `brain`           |  The simulators Brain object. |
+| `name`            |  The simulators name. |
 | `objective_name`  |  The name of the current objective for an episode. |
 | `episode_reward`  |  Cumulative reward for this episode so far. |
 | `episode_count`   |  Number of completed episodes since sim launch. |
@@ -38,31 +38,39 @@ end
 
 > Example code:
 
-```python
-class MySimulator(bonsai_ai.Simulator):
-    def __init__(brain, name):
-        super().__init__(brain, name)
-        # your sim init code goes here.
+```cpp
+class MySimulator : public Simulator {
+ public:
+    explicit BasicSimulator(std::shared_ptr<Brain> brain, string name)
+        : Simulator(move(brain), move(name)) {
+            // your simulator init code goes here.
+        }
 
-    def episode_start(self, parameters=None):
-        # your reset/init code goes here.
-        return my_state
+    void episode_start(const bonsai::InklingMessage& params,
+        bonsai::InklingMessage& initial_state) override {
+            // your simulation episode reset/init code.
+        }
 
-    def simulate(self, action):
-        # your simulation stepping code goes here.
-        return (my_state, my_reward, is_terminal)
+    void simulate(const bonsai::InklingMessage& action,
+        bonsai::InklingMessage& state,
+        float& reward,
+        bool& terminal) override {
+            // your simulation stepping code.
+        }
 
-    def episode_finish(self):
-        # your post episode code goes here.
-        pass
+    void episode_finish() override {
+            // your post-episode code.
+        }
+};
 
 ...
 
-config = bonsai_ai.Config(sys.argv)
-brain = bonsai_ai.Brain(config)
-sim = MySimulator(brain, "my_simulator")
+auto config = make_shared<bonsai::Config>(argc, argv);
+auto brain = make_shared<bonsai::Brain>(config);
+MySimulator sim(brain, "my_simulator");
 
 ...
+
 ```
 
 Serves as a base class for running simulations. You should create a subclass
@@ -75,42 +83,48 @@ of Simulator and implement the `episode_start` and `simulate` callbacks.
 
 ## Brain brain()
 
-```python
-print(sim.brain)
+```cpp
+std::cout << sim.brain() << endl;
 ```
 
 Returns the BRAIN being used for this simulation.
 
-## name()
+## string name()
 
-```python
-print("Starting ", sim.name)
+```cpp
+std::cout << "Starting " << sim.name() << endl;
 ```
+
 Returns the simulator name that was passed in when constructed.
 
-## predict()
+## bool predict()
 
-```python
-def simulate(self, action):
-    if self.predict is False:
-        # calculate reward...
+```cpp
+void MySimulator::simulate(const bonsai::InklingMessage& action,
+                    bonsai::InklingMessage& state, float& reward, bool& terminal) {
+    if (predict() == false) {
+        // calculate reward...
+    }
 
     ...
+}
 ```
 
 Returns a value indicating whether the simulation is set up to run in predict mode or training mode.
 
-## objective_name()
+## string objective_name()
 
-```python
-def episode_start(self, params):
-    print(self.objective_name)
+```cpp
+void MySimulator::episode_start(const bonsai::InklingMessage& params,
+                                bonsai::InklingMessage& initial_state) {
+    cout << objective_name() << endl;
     ...
+}
 ```
 
 Property accessor that returns the name of the current objective from Inkling.
 The objective may be updated before `episode_start` is called. When running
-for prediction and during start up, objective will return an empty string.
+for prediction and during start up, objective will return an empty std::string.
 
 ## episode_start(parameters, initial_state)
 
@@ -129,18 +143,18 @@ end
 
 > Example code:
 
-```python
-def episode_start(self, params):
-    # training params are only passed in during training
-    if self.predict == False:
-        print(self.objective_name)
-        self.angle = params.start_angle
-
-    initial = {
-        "angle": self.angle,
-        "velocity": self.velocity,
+```cpp
+void MySimulator::episode_start(const bonsai::InklingMessage& params,
+                                bonsai::InklingMessage& initial_state) {
+    // training params are only passed in during training
+    if (predict() == false) {
+        cout << objective_name() << endl;
+        angle = params.get_float32("start_angle");
     }
-    return initial
+
+    initial_state.set_float32("velocity", velocity);
+    initial_state.set_float32("angle",    angle);
+}
 ```
 
 | Argument        | Description |
@@ -168,20 +182,20 @@ end
 
 > Example code:
 
-```python
-def simulate(self, action):
-    velocity = velocity - action.delta;
-    terminal = (velocity <= 0.0)
+```cpp
+void MySimulator::simulate(const bonsai::InklingMessage& action,
+                           bonsai::InklingMessage& state, float& reward, bool& terminal) {
+    velocity = velocity - action.get_int8("delta");
+    terminal = (velocity <= 0.0);
 
-    # reward is only needed during training
-    if self.predict == False:
-        reward = reward_for_objective(self.objective_name)
-
-    state = {
-        "velocity": self.velocity,
-        "angle": self.angle,
+    // reward is only needed during training.
+    if (self.predict() == false) {
+        reward = reward_for_objective(objective_name());
     }
-    return (state, reward, terminal)
+
+    state.set_float32("velocity", velocity);
+    state.set_float32("angle",    angle);
+}
 ```
 
 | Argument   | Description |
@@ -204,18 +218,18 @@ Returning `true` for the `terminal` flag signals the start of a new episode.
 
 The default implementation will throw an exception.
 
-## run()
+## bool run()
 
-```python
-sim = MySimulator(brain)
+```cpp
+MySimulator sim(brain);
 
-if sim.predict:
-    print("Predicting against ", brain.name, " version ", brain.version)
-else:
-    print("Training ", brain.name)
+if (sim.predict())
+    std::cout << "Predicting against " << brain.name() << " version " << brain.version() << endl;
+else
+    std::cout << "Training " << brain.name() << endl;
 
-while sim.run():
-    continue
+while( sim.run() ) {
+}
 ```
 
 Main loop call for driving the simulation. Returns `false` when the
@@ -226,10 +240,10 @@ To run for prediction, `brain()->config()->predict()` must return `true`.
 
 ## episode_finish()
 
-```python
-def episode_finish(self):
-    print('Episode:', self.episode_count,
-          'reward:', self.episode_reward)
+```cpp
+void MySimulator::episode_finish() {
+    cout << 'Episode: ' << episode_count() << ' reward:' << episode_reward() << endl;
+}
 ```
 
 This callback is called at the end of each episode. You can use it to log
@@ -237,12 +251,12 @@ out statistical information, or perform post episode cleanup.
 
 ## record_file()
 
-```python
-my_sim.record_file == "/path/to/foobar.json"
-my_sim.record_file = "/path/to/barfoo.json"
+```cpp
+my_sim.record_file() == "/path/to/foobar.json";
+my_sim.set_record_file("/path/to/barfoo.json");
 
-my_sim.record_file == "/path/to/foobar.csv"
-my_sim.record_file = "/path/to/foobar.csv"
+my_sim.record_file() == "/path/to/foobar.csv";
+my_sim.set_record_file("/path/to/barfoo.csv");
 ```
 
 Getter and setter for analytics recording file.
@@ -250,15 +264,6 @@ Getter and setter for analytics recording file.
 When a new record file is set, the previous file will be closed immediately. Subsequent log lines will be written to the new file.
 
 ## enable_keys(keys, prefix=None)
-
-```python
-if __name__ == "__main__":
-    config = Config(sys.argv)
-    brain = Brain(config)
-    sim = MySimulator(brain)
-    sim.enable_keys(["foo", "bar"])
-    sim.enable_keys(["baz"], "qux")
-```
 
 This function adds the given keys to the log schema for this writer.
 If one is provided, the prefix will be prepended to those keys and
@@ -269,74 +274,74 @@ You should enable any keys you expect to see in the logs. If you
 attempt to insert objects containing keys which have not been
 enabled, those keys will be silently ignored.
 
+```cpp
+int main(int argc, char** argv) {
+    auto config = std::make_shared<bonsai::Config>(argc, argv);
+    auto brain = std::make_shared<Brain>(config);
+    MySim sim(brain);
+    sim.enable_keys({"foo", "bar"});
+    sim.enable_keys({"baz"}, "qux");
+}
+```
+
 | Argument   | Description |
 | ---        | ---         |
 | `keys`     | A list/vector of strings to include as keys in log entries for this simulator. |
-| `prefix`   | A `string` used as a subdomain for the given `keys`. Entries will appear as `<prefix>.<key>` for each `key` in `keys`. Defaults to empty string. |
+| `prefix`   | A `std::string` used as a subdomain for the given `keys`. Entries will appear as `<prefix>.<key>` for each `key` in `keys`. Defaults to empty string. |
 
-## record_append(obj, prefix=None)
+## record_append(key, value, prefix="")
 
-```python
-if __name__ == "__main__":
-    config = Config(sys.argv)
-    brain = Brain(config)
-    sim = MySimulator(brain)
-    sim.enable_keys(["foo", "bar"])
-    sim.enable_keys(["baz"], "qux")
-    while sim.run():
-        sim.record_append({
-            "foo": 23,
-            "bar": 5
-        })
-        sim.record_append({
-            "baz": "zabow"
-        }, "qux")
+Adds the given key (prepended by `prefix`, if provided) and value to the current log entry. If the specified
+key is not enabled or recording is not enabled, this method has no effect.
+
+The following `value` types are supported:
+- `int64_t`
+- `size_t`
+- `double`
+- `std::string`
+- `bool`
+
+**Note:** The template specializations in the following snippet are included for completeness. If the `value` parameter is of one of the supported types, the correct specialization will be deduced by the compiler.
+
+```cpp
+int main(int argc, char** argv) {
+    auto config = std::make_shared<bonsai::Config>(argc, argv);
+    config.set_recording_enabled(true);
+    config.set_record_filie("foobar.json");
+    auto brain = std::make_shared<Brain>(config);
+    MySim sim(brain);
+    sim.enable_keys({"foo", "bar", "oof", "rab"});
+    sim.enable_keys({"baz"}, "qux");
+
+    while (sim.run()) {
+        sim.record_append<int64_t>("foo", -23);
+        sim.record_append<size_t>("bar", 123);
+        sim.record_append<double>("oof", .023);
+        sim.record_append<std::string>("rab", "foobar");
+        sim.record_append<bool>("baz", true, "qux");
+        sim.record_append<int64_t>("nope", 23);
+    }
+}
 ```
-
-
-Adds the keys (prepended by `prefix`, if provied) from the given dictionary to the current log entry. If recording is not enabled, this method has no effect. If a particular subset of the keys in `obj` are not enabled, they will be ignored silently.
 
 | Argument   | Description |
 | ---        | ---         |
-| `obj`      | A dictionary containing data to be added to the current log entry. |
-| `prefix`   | String prefix for the keys in `obj`. |
-
-## get_next_event()
-
-```python
-if __name__ == "__main__":
-    config = Config(sys.argv)
-    brain = Brain(config)
-    sim = MySimulator(brain)
-    
-    while True:
-        event = sim.get_next_event()
-        if isinstance(event, EpisodeStartEvent):
-            state = sim.episode_start(event.initial_properties)
-            event.initial_state = state
-        elif isinstance(event, SimulateEvent):
-            state, reward, terminal = sim.simulate(event.action)
-            event.state = state
-            event.reward = float(reward)
-            event.terminal = bool(terminal)
-        elif isinstance(event, EpisodeFinishEvent):
-            sim.episode_finish()
-        elif isinstance(event, FinishedEvent):
-            sim.close()
-            break
-        elif isinstance(event, UnknownEvent):
-            pass
-```
-
-Advance the SDK's internal state machine and return an event for processing.
-
-This is the primary entrypoint for the "Event Pump" interface. With this,
-custom run loop implementations are possible in user code. Rather than calling
-`Simulator.run` in a loop, communication between simulation code and Bonsai backend
-can be accomplished step by step.
+| `key`      | A `std::string` used as an index into the current log entry. |
+| `value`    | The value to add under `<prefix>.<key>`. May be any of `int64_t`, `size_t`, `double`, `std::string`, or `bool` |
+| `prefix`   | String prefix for `key`. Keys should be enabled and added with the same prefix. |
 
 ## close()
 
 Close the internal websocket.
 
+## operator<<(ostream, simulator)
+
+Prints out a representation of Simulator that is useful for debugging.
+
+**Note:** Used in C++ only. For python, use `print(simulator)`
+
+| Argument  | Description |
+| ---       | ---         |
+| `ostream` | A std c++ stream operator. |
+| `simulator`  | A bonsai::Simulator to print out. |
 

--- a/source/includes/library-reference/_brain.html.md
+++ b/source/includes/library-reference/_brain.html.md
@@ -24,7 +24,7 @@ Creates a local object for interacting with an existing BRAIN on the server.
 
 | Argument | Description |
 | ---      | ---         |
-| `config` | Object returned by previously created `bonsai_ai.Config()`. |
+| `config` | Object returned by previously created `bonsai_ai.Config`. |
 | `name`   | BRAIN name as specified on the server. If name is empty, the BRAIN name in `config` is used instead. |
 
 ## update()
@@ -36,7 +36,7 @@ brain.update()
 Refreshes description, status, and other information with the current state of the BRAIN on the server.
 Called by default when constructing a new Brain object.
 
-## name()
+## name
 
 ```python
 print(brain.name)
@@ -44,7 +44,7 @@ print(brain.name)
 
 Returns the name of the BRAIN as specified when it was created.
 
-## description()
+## description
 
 ```python
 print(brain.description)
@@ -52,7 +52,7 @@ print(brain.description)
 
 Returns the user-provided description for the BRAIN.
 
-## version()
+## version
 
 ```python
 print(brain.version)
@@ -60,7 +60,7 @@ print(brain.version)
 
 Returns the current version number of the BRAIN.
 
-## latest_version()
+## latest_version
 
 ```python
 print(brain.latest_version)
@@ -68,7 +68,7 @@ print(brain.latest_version)
 
 Returns latest version number of the BRAIN.
 
-## Config config()
+## Config config
 
 ```python
 print(brain.config)

--- a/source/includes/library-reference/_config.html.md
+++ b/source/includes/library-reference/_config.html.md
@@ -176,6 +176,46 @@ my_config.brain_version = 0
 BRAIN version.
 The version of the brain to use when running for prediction. Set to 0 to use latest version.
 
+## record_file()
+
+```cpp
+my_config.record_file() == "foobar.json";
+my_config.set_record_file("foobar.json");
+```
+
+```python
+my_config.record_file == "foobar.json"
+my_config.record_file = "foobar.json"
+```
+
+This property defines the destination for log recording. Additionally, the format for log recording is inferred from the file extension. Currently supported options are `json` and `csv`. Missing file extension or use of an unsupported extension will result in runtime errors.
+
+## record_enabled()
+
+```cpp
+my_config.record_enabled() == true;
+my_config.set_record_enabled(true);
+```
+
+```python
+my_config.record_enabled == True
+my_config.record_enabled = True
+```
+
+## record_format()
+
+```cpp
+my_config.record_file() == "foobar.json";
+my_config.record_format() == "json";
+```
+
+```python
+my_config.record_file == "foobar.json"
+my_config.record_format == "json";
+```
+
+**Note:** This property cannot be set directly. It reflects the file extension of the currently configured `record_file`. `json` or `csv` are valid.
+
 ## operator<<(ostream, config)
 
 Will print out a representation of Config that is useful for debugging.

--- a/source/includes/library-reference/_config.html.md
+++ b/source/includes/library-reference/_config.html.md
@@ -59,7 +59,7 @@ To see the list of command line arguments, pass in the `--help` flag.
 
 Unrecognized arguments will be ignored.
 
-## accesskey()
+## accesskey
 
 ```python
 my_config.accesskey == '00000000-1111-2222-3333-000000000001'
@@ -69,7 +69,7 @@ my_config.accesskey = '00000000-1111-2222-3333-000000000001'
 Server authentication token.
 Obtained from the bonsai server. You need to set it in your config.
 
-## username()
+## username
 
 ```python
 my_config.username == 'alice'
@@ -79,7 +79,7 @@ my_config.username = 'alice'
 Account user name.
 The account you signed up with.
 
-## url()
+## url
 
 ```python
 my_config.url == 'https://api.bons.ai'
@@ -89,7 +89,7 @@ my_config.url = 'https://api.bons.ai'
 Server URL.
 Address and port number of the bonsai server. Normally you should not need to change this.
 
-## proxy()
+## proxy
 
 ```python
 my_config.proxy == 'myproxy:5000'
@@ -99,7 +99,7 @@ my_config.proxy = 'myproxy:5000'
 Proxy Server.
 Address and port number of the proxy server to connect through.
 
-## brain()
+## brain
 
 ```python
 my_config.brain == 'scarecrow'
@@ -109,7 +109,7 @@ my_config.brain = 'scarecrow'
 BRAIN name.
 Name of the BRAIN on the server.
 
-## predict()
+## predict
 
 ```python
 my_config.predict == True
@@ -119,7 +119,7 @@ my_config.brain = True
 Simulator mode.
 The mode in which simulators will run. True if running for prediction, false for training.
 
-## brain_version()
+## brain_version
 
 ```python
 my_config.brain_version == 0
@@ -129,7 +129,7 @@ my_config.brain_version = 0
 BRAIN version.
 The version of the brain to use when running for prediction. Set to 0 to use latest version.
 
-## record_file()
+## record_file
 
 ```python
 my_config.record_file == "foobar.json"
@@ -138,14 +138,14 @@ my_config.record_file = "foobar.json"
 
 This property defines the destination for log recording. Additionally, the format for log recording is inferred from the file extension. Currently supported options are `json` and `csv`. Missing file extension or use of an unsupported extension will result in runtime errors.
 
-## record_enabled()
+## record_enabled
 
 ```python
 my_config.record_enabled == True
 my_config.record_enabled = True
 ```
 
-## record_format()
+## record_format
 
 ```python
 my_config.record_file == "foobar.json"

--- a/source/includes/library-reference/_event.html.md
+++ b/source/includes/library-reference/_event.html.md
@@ -1,0 +1,139 @@
+# Event
+
+## Event Class (Python)
+
+Base class.
+
+###### EpisodeStartEvent
+
+This event is generated at the start of a training episode.
+It is triggered either by a terminal condition in the simulator
+or by the platform itself.
+
+| Argument | Description |
+| ---      | ---         |
+| `initial_properties`  |  Configuration properties for the simulator. |
+| `initial_state`   |  Assign the state resulting from a model reset. |
+
+```python
+event = sim.get_next_event()
+if isinstance(event, EpisodeStartEvent):
+    state = sim.episode_start(event.initial_properties)
+    event.initial_state = state
+```
+
+###### SimulateEvent
+
+This event is generated when an action (prediction) is ready
+to be fed into the simulator.
+
+| Argument | Description |
+| ---      | ---         |
+| `action`  |  Next action (prediction) in the queue. |
+| `state`   |  Assign the resulting state after updating the model. |
+| `reward`   |  The reward calculated from the updated. |
+| `terminal`   |  Whether the updated state is terminal. |
+
+```python
+event = sim.get_next_event()
+if isinstance(event, SimulateEvent):
+    state, reward, terminal = sim.simulate(event.action)
+    event.state = state
+    event.reward = float(reward)
+    event.terminal = bool(terminal)
+```
+
+###### FinishedEvent
+
+Indicates that the Bonsai Platform has terminated training.
+
+```python
+event = get_next_event()
+if isinstance(event, FinishedEvent):
+    self.close()
+```
+ 
+###### UnknownEvent
+
+Catch-all event for other internal states. This event can be safely ignored,
+but it is provided for completeness and is handy for explicitly tracking state
+transitions from client code.
+
+
+
+## Event Class (C++)
+
+Base class for encapsulating Simulator state. Event types correspond to different
+procedures in client code (see `enum class Type`).
+
+This class is abstract and contains a static factory method for its derived classes, each of which
+corresponds to a distinct Type.
+
+### enum class Type
+
+| Argument       | Description |
+| ----           | ----        |
+| `Episode_Start`|  Reset the simulator and set initial state. |
+| `Simulate`     |  Advance the simulation with the next prediction and record resulting state. |
+| `Finished`     |  Simulation complete. BRAIN does not expect further state data. |
+| `Unknown`      |  No event corresponding to last message exchange. |
+
+```cpp
+auto event = get_next_event();
+if (event->type() == Type::Episode_Start) {
+    auto es_E = dynamic_pointer_cast<EpisodeStartEvent>(event);
+    auto initial_properties = es_E->initial_properties;
+    auto initial_state = es_E->initial_state;
+    // process initial properties/state
+} else if (event->type() == Type::Simulate) {
+    auto sim_E = dynamic_pointer_cast<SimulatorEvent>(event);
+    auto prediction = sim_E->prediction;
+    auto state = sim_E->state;
+    auto reward = sim_E->reward;
+    auto terminal = sim_E->terminal;
+    // process simulator step 
+} else if (event->type() == Type::Finished) {
+    close();
+}
+```
+
+### Type type()
+Returns the Type of the Event. Implemented for each specialization of Event.
+
+###### EpisodeStartEvent Class
+Signals a boundary between training episodes. Requires resetting the simulation environment
+and returning its initial state to the **BRAIN**.
+
+### std::shared_ptr<const InklingMessage> initial_properties
+Settings used when resetting the simulation environment.
+
+### std::shared_ptr<InklingMessage> initial_state
+Directly manipulate to reflect the state resulting from sim environment reset.
+
+See `InklingMessage` API for detail.
+
+###### SimulateEvent Class
+Signals that the **BRAIN** is ready to receive the simulator state resulting from
+the next prediction in the queue.
+
+### std::shared_ptr<const InklingMessage> prediction
+The prediction (action) intended for the next simulation step.
+
+### std::shared_ptr<InklingMessage> state
+Directly manipulate to reflect the state resulting from applying `prediction`
+to the simulation environment.
+
+See `InklingMessage` API for detail.
+
+### std::shared_ptr<float> reward
+Directly manipulate to reflect the reward corresponding to `state`.
+
+### std::shared_ptr<bool> terminal
+Directly manipulate to reflect whether the current `state` is terminal.
+
+###### FinishedEvent Class
+Signals that the **BRAIN** is done training. No more simulation steps are expected.
+
+###### UnknownEvent Class
+Signals that no action is required.
+

--- a/source/includes/library-reference/_event.html.md
+++ b/source/includes/library-reference/_event.html.md
@@ -1,19 +1,8 @@
-# Event
+# Event Class
 
-## Event Class (Python)
+[Need text on what this is for and when someone might want to use it.]
 
-Base class.
-
-###### EpisodeStartEvent
-
-This event is generated at the start of a training episode.
-It is triggered either by a terminal condition in the simulator
-or by the platform itself.
-
-| Argument | Description |
-| ---      | ---         |
-| `initial_properties`  |  Configuration properties for the simulator. |
-| `initial_state`   |  Assign the state resulting from a model reset. |
+## EpisodeStartEvent
 
 ```python
 event = sim.get_next_event()
@@ -22,17 +11,16 @@ if isinstance(event, EpisodeStartEvent):
     event.initial_state = state
 ```
 
-###### SimulateEvent
+This event is generated at the start of a training episode.
+It is triggered either by a terminal condition in the simulator
+or by the platform itself.
 
-This event is generated when an action (prediction) is ready
-to be fed into the simulator.
-
-| Argument | Description |
+| Attribute | Description |
 | ---      | ---         |
-| `action`  |  Next action (prediction) in the queue. |
-| `state`   |  Assign the resulting state after updating the model. |
-| `reward`   |  The reward calculated from the updated. |
-| `terminal`   |  Whether the updated state is terminal. |
+| `initial_properties`  |  Configuration properties for the simulator. |
+| `initial_state`   |  Assign the state resulting from a model reset. |
+
+## SimulateEvent
 
 ```python
 event = sim.get_next_event()
@@ -43,97 +31,30 @@ if isinstance(event, SimulateEvent):
     event.terminal = bool(terminal)
 ```
 
-###### FinishedEvent
+This event is generated when an action (prediction) is ready
+to be fed into the simulator.
 
-Indicates that the Bonsai Platform has terminated training.
+| Attribute | Description |
+| ---      | ---         |
+| `action`  |  Next action (prediction) in the queue. |
+| `state`   |  Assign the resulting state after updating the model. |
+| `reward`   |  The reward calculated from the updated. |
+| `terminal`   |  Whether the updated state is terminal. |
+
+## FinishedEvent
 
 ```python
 event = get_next_event()
 if isinstance(event, FinishedEvent):
     self.close()
 ```
- 
-###### UnknownEvent
+
+Indicates that the Bonsai Platform has terminated training.
+
+## UnknownEvent
 
 Catch-all event for other internal states. This event can be safely ignored,
 but it is provided for completeness and is handy for explicitly tracking state
 transitions from client code.
 
-
-
-## Event Class (C++)
-
-Base class for encapsulating Simulator state. Event types correspond to different
-procedures in client code (see `enum class Type`).
-
-This class is abstract and contains a static factory method for its derived classes, each of which
-corresponds to a distinct Type.
-
-### enum class Type
-
-| Argument       | Description |
-| ----           | ----        |
-| `Episode_Start`|  Reset the simulator and set initial state. |
-| `Simulate`     |  Advance the simulation with the next prediction and record resulting state. |
-| `Finished`     |  Simulation complete. BRAIN does not expect further state data. |
-| `Unknown`      |  No event corresponding to last message exchange. |
-
-```cpp
-auto event = get_next_event();
-if (event->type() == Type::Episode_Start) {
-    auto es_E = dynamic_pointer_cast<EpisodeStartEvent>(event);
-    auto initial_properties = es_E->initial_properties;
-    auto initial_state = es_E->initial_state;
-    // process initial properties/state
-} else if (event->type() == Type::Simulate) {
-    auto sim_E = dynamic_pointer_cast<SimulatorEvent>(event);
-    auto prediction = sim_E->prediction;
-    auto state = sim_E->state;
-    auto reward = sim_E->reward;
-    auto terminal = sim_E->terminal;
-    // process simulator step 
-} else if (event->type() == Type::Finished) {
-    close();
-}
-```
-
-### Type type()
-Returns the Type of the Event. Implemented for each specialization of Event.
-
-###### EpisodeStartEvent Class
-Signals a boundary between training episodes. Requires resetting the simulation environment
-and returning its initial state to the **BRAIN**.
-
-### std::shared_ptr<const InklingMessage> initial_properties
-Settings used when resetting the simulation environment.
-
-### std::shared_ptr<InklingMessage> initial_state
-Directly manipulate to reflect the state resulting from sim environment reset.
-
-See `InklingMessage` API for detail.
-
-###### SimulateEvent Class
-Signals that the **BRAIN** is ready to receive the simulator state resulting from
-the next prediction in the queue.
-
-### std::shared_ptr<const InklingMessage> prediction
-The prediction (action) intended for the next simulation step.
-
-### std::shared_ptr<InklingMessage> state
-Directly manipulate to reflect the state resulting from applying `prediction`
-to the simulation environment.
-
-See `InklingMessage` API for detail.
-
-### std::shared_ptr<float> reward
-Directly manipulate to reflect the reward corresponding to `state`.
-
-### std::shared_ptr<bool> terminal
-Directly manipulate to reflect whether the current `state` is terminal.
-
-###### FinishedEvent Class
-Signals that the **BRAIN** is done training. No more simulation steps are expected.
-
-###### UnknownEvent Class
-Signals that no action is required.
 

--- a/source/includes/library-reference/_event.html.md
+++ b/source/includes/library-reference/_event.html.md
@@ -1,6 +1,10 @@
 # Event Class
 
-[Need text on what this is for and when someone might want to use it.]
+Internally, the Bonsai library uses a state machine to drive activity in user code (i.e. advancing and recording simulator state, resetting a simulator, etc). State transfer is driven primarily by a websocket-based messaging protocol shared between the library and the Bonsai AI platform. For your convenience, the details of this protocol have been hidden behind a pair of API's, one based on callbacks in `bonsai_ai.Simulator` and the other event driven.
+
+Filling out the callbacks in `bonsai_ai.Simulator` and relying on `Simulator.run` to invoke them at the appropriate time will be sufficient for many use cases. For example, if you have a simulator which can be advanced, reset, and observed in a synchronous manner from Python or C++ code, your application is likely amenable to our callback API. However, if, for example, your simulator is free running and communicates with your application code asynchronously, your application will likely need to employ the event driven API described below.
+
+In the **event-driven mode of operation**, you application code should implement its own run loop by requesting successive events from the Bonsai library and handling them in a way that is appropriate to your particular simulation or deployment architecture. For example, if your simulator invokes callbacks into your code and is reset in response to some outgoing signal (i.e. not via a method call), you might respond to an `EpisodeStartEvent` by setting the appropriate flag, returning control to the simulator, and returning the resulting state to the Bonsai platform the next time your callback gets invoked.
 
 ## EpisodeStartEvent
 

--- a/source/includes/library-reference/_logger.html.md
+++ b/source/includes/library-reference/_logger.html.md
@@ -1,14 +1,10 @@
-# Logging
+# Logger Class
 
-## Logger Class (Python)
-
-In python, the `Logger` class serves as an entry point for runtime logging to `stderr`. All instances of `Logger` 
+The `Logger` class serves as an entry point for runtime logging to `stderr`. All instances of `Logger` 
 share the same internal state, so enabling a particular log domain for a `Logger` in any scope
 enables that log domain for all `Logger` instances in the current process.
 
-### Logger()
-
-> Example code: 
+## Logger()
 
 ```python
 from bonsai_ai.logger import Logger
@@ -29,9 +25,7 @@ if __name__ == "__main__":
 
 Return an instance of `Logger` that reflects the shared state of all active Loggers.
 
-### set_enabled(key)
-
-> Example code:
+## set_enabled(key)
 
 ```python
 log = bonsai_ai.logger.Logger()
@@ -47,9 +41,7 @@ Enables the given log domain for all active Loggers.
 | `key` | A string describing which log domain to enable. |
 
 
-### set_enable_all(enable_all)
-
-> Example code:
+## set_enable_all(enable_all)
 
 ```python
 log = bonsai_ai.logger.Logger()
@@ -64,109 +56,4 @@ was explicitly enabled. Corresponds to the `--verbose` command line flag.
 | Argument  | Description |
 | ---       | ---         |
 | `enable_all` | A bool describing whether verbose logging is enabled. |
-
-
-## logging Class (C++)
-
-In C++, runtime logging is accomplished using the `BONSAI_LOG` macro, which  `BONSAI_LOG` may be invoked
-freely on log domains of your choosing, but the accompanying messages will only be printed if
-a given domain has been enabled either through command line flags (see `bonsai::Config`) or
-through `bonsai::logging::set_enabled`.
-
-Consumers of `bonsai::logging` may enable a custom handler for `BONSAI_LOG` via
-`logging::set_handler`. By default, logs print to `stderr`.
-
-Additionally, use `logging::set_use_colors` to enable/disable ASCII colors in log output.
-
-> Example code:
-
-```cpp
-using bonsai::logging;
-
-class MySimulator : public Simulator {
-...
-    void simulate(const bonsai::InklingMessage& action,
-                   bonsai::InklingMessage& state,
-                   float& reward, bool& terminal) {
-        ...
-        BONSAI_LOG(foobar, "things (" << reward << ") stuff"); // logged
-        BONSAI_LOG(barfoo, "things (" << reward << ") stuff"); // not logged
-        ...
-    }
-...
-};
-int main() {
-    ...
-    logging::log().set_enabled(true)
-    logging::log().set_enabled("foobar")
-    ...
-}
-```
-
-### BONSAI_LOG(domain, message)
-
-`BONSAI_LOG` is a preprocessor macro defined in `logging.hpp`. It encapsulates various calls into
-the `logging` singleton and performs the necessary domain checks and I/O procedures without the
-overhead of an additional function call.
-
-> Example code:
-
-```cpp
-void MySimulator::simulate() {
-    ...
-    BONSAI_LOG(foobar, "my hovercraft has " << val << "eels");
-    ...
-}
-```
-
-The log domain should not include quotes. It will be quoted into a string literal at preprocessor time.
-
-Similarly, the message will be interpolated into an expression of the form `std::cerr << X << std::endl;`. As such, `message` can be any expression which produces syntactically correct C++  when substituted for X in an expression of that form.
-
-### enabled()
-
-Global switch to enable/disable logging.
-
-```cpp
-bonsai::logging::log().enabled() == false;
-bonsai::logging::log().set_enabled(true);
-```
-
-Individual switches to enable/disable specific domains.
-
-```cpp
-bonsai::logging::log().enabled("foobar") == false;
-bonsai::logging::log().set_enabled("foobar");
-```
-
-### enabled_all()
-
-Switch to enable/disable verbose logging.
-
-```cpp
-bonsai::logging::log().enabled_all() == true;
-bonsai::logging::log().set_enable_all(true);
-```
-
-### use_colors
-
-Switch to enable/disable ASCII colors in log output. Enabled by default.
-
-```cpp
-bonsai::logging::log().use_colors() == true;
-bonsai::logging::log().set_use_colors(false);
-```
-
-### set_handler(function\<void(stringstream&)\>)
-
-Set a custom handler for `BONSAI_LOG`. Instead of streaming directly to 
-`std::cerr`, each log line will be passed to this custom handler in the form of a `std::stringstream`.
-
-> Example code:
-
-```cpp
-bonsai::logging::log().set_handler([](std::stringstream& ss) {
-    printf("%s", ss.str().c_str());
-});
-```
 

--- a/source/includes/library-reference/_predictor.html.md
+++ b/source/includes/library-reference/_predictor.html.md
@@ -29,13 +29,8 @@ action = predictor.get_action(state)
 predictor.close()
 ```
 
-```cpp
-# Not yet implemented
-```
-
 This class is used to interface with the server to obtain predictions for a specific BRAIN and
-is a subclass of Simulator. This class is currently unavailable in `libbonsai` so only Python
-implementations are shown.
+is a subclass of Simulator.
 
 The `Predictor` class is closely related to the Inkling file that is associated with the BRAIN.
 The name used to construct `Predictor` must match the name of the simulator in the Inkling file.

--- a/source/includes/library-reference/_simulator.html.md
+++ b/source/includes/library-reference/_simulator.html.md
@@ -339,6 +339,171 @@ def episode_finish(self):
 This callback is called at the end of each episode. You can use it to log
 out statistical information, or perform post episode cleanup.
 
+## record_file()
+
+```cpp
+my_sim.record_file() == "/path/to/foobar.json";
+my_sim.set_record_file("/path/to/barfoo.json");
+
+my_sim.record_file() == "/path/to/foobar.csv";
+my_sim.set_record_file("/path/to/barfoo.csv");
+```
+
+```python
+my_sim.record_file == "/path/to/foobar.json"
+my_sim.record_file = "/path/to/barfoo.json"
+
+my_sim.record_file == "/path/to/foobar.csv"
+my_sim.record_file = "/path/to/foobar.csv"
+```
+
+Getter and setter for analytics recording file.
+
+When a new record file is set, the previous file will be closed immediately. Subsequent log lines will be written to the new file.
+
+## enable_keys(keys, prefix=None)
+
+This function adds the given keys to the log schema for this writer.
+If one is provided, the prefix will be prepended to those keys and
+they will appear as such in the resulting logs.
+If recording is not enabled, this method has no effect.
+    
+You should enable any keys you expect to see in the logs. If you
+attempt to insert objects containing keys which have not been
+enabled, those keys will be silently ignored.
+
+```cpp
+int main(int argc, char** argv) {
+    auto config = std::make_shared<bonsai::Config>(argc, argv);
+    auto brain = std::make_shared<Brain>(config);
+    MySim sim(brain);
+    sim.enable_keys({"foo", "bar"});
+    sim.enable_keys({"baz"}, "qux");
+}
+```
+
+```python
+if __name__ == "__main__":
+    config = Config(sys.argv)
+    brain = Brain(config)
+    sim = MySimulator(brain)
+    sim.enable_keys(["foo", "bar"])
+    sim.enable_keys(["baz"], "qux")
+```
+
+| Argument   | Description |
+| ---        | ---         |
+| `keys`     | A list/vector of strings to include as keys in log entries for this simulator. |
+| `prefix`   | A `std::string` used as a subdomain for the given `keys`. Entries will appear as `<prefix>.<key>` for each `key` in `keys`. Defaults to empty string. |
+
+## record_append(key, value, prefix="")
+
+**Note:** Used in C++ only. For python, use `record_append(obj, prefix)`.
+
+Adds the given key (prepended by `prefix`, if provided) and value to the current log entry. If the specified
+key is not enabled or recording is not enabled, this method has no effect.
+
+The following `value` types are supported:
+- `int64_t`
+- `size_t`
+- `double`
+- `std::string`
+- `bool`
+
+**Note:** The template specializations in the following snippet are included for completeness. If the `value` parameter is of one of the supported types, the correct specialization will be deduced by the compiler.
+
+```cpp
+int main(int argc, char** argv) {
+    auto config = std::make_shared<bonsai::Config>(argc, argv);
+    config.set_recording_enabled(true);
+    config.set_record_filie("foobar.json");
+    auto brain = std::make_shared<Brain>(config);
+    MySim sim(brain);
+    sim.enable_keys({"foo", "bar", "oof", "rab"});
+    sim.enable_keys({"baz"}, "qux");
+
+    while (sim.run()) {
+        sim.record_append<int64_t>("foo", -23);
+        sim.record_append<size_t>("bar", 123);
+        sim.record_append<double>("oof", .023);
+        sim.record_append<std::string>("rab", "foobar");
+        sim.record_append<bool>("baz", true, "qux");
+        sim.record_append<int64_t>("nope", 23);
+    }
+}
+```
+
+| Argument   | Description |
+| ---        | ---         |
+| `key`      | A `std::string` used as an index into the current log entry. |
+| `value`    | The value to add under `<prefix>.<key>`. May be any of `int64_t`, `size_t`, `double`, `std::string`, or `bool` |
+| `prefix`   | String prefix for `key`. Keys should be enabled and added with the same prefix. |
+
+## record_append(obj, prefix=None)
+
+**Note:** Used in Python only. For C++, use `record_append(key, value, prefix)`.
+
+Adds the keys (prepended by `prefix`, if provied) from the given dictionary to the current log entry. If recording is not enabled, this method has no effect. If a particular subset of the keys in `obj` are not enabled, they will be ignored silently.
+
+```python
+if __name__ == "__main__":
+    config = Config(sys.argv)
+    brain = Brain(config)
+    sim = MySimulator(brain)
+    sim.enable_keys(["foo", "bar"])
+    sim.enable_keys(["baz"], "qux")
+    while sim.run():
+        sim.record_append({
+            "foo": 23,
+            "bar": 5
+        })
+        sim.record_append({
+            "baz": "zabow"
+        }, "qux")
+```
+
+| Argument   | Description |
+| ---        | ---         |
+| `obj`      | A dictionary containing data to be added to the current log entry. |
+| `prefix`   | String prefix for the keys in `obj`. |
+
+## get_next_event()
+Advance the SDK's internal state machine and return an event for processing.
+
+This is the primary entrypoint for the "Event Pump" interface. With this,
+custom run loop implementations are possible in user code. Rather than calling
+`Simulator.run` in a loop, communication between simulation code and Bonsai backend
+can be accomplished step by step.
+
+```python
+if __name__ == "__main__":
+    config = Config(sys.argv)
+    brain = Brain(config)
+    sim = MySimulator(brain)
+    
+    while True:
+        event = sim.get_next_event()
+        if isinstance(event, EpisodeStartEvent):
+            state = sim.episode_start(event.initial_properties)
+            event.initial_state = state
+        elif isinstance(event, SimulateEvent):
+            state, reward, terminal = sim.simulate(event.action)
+            event.state = state
+            event.reward = float(reward)
+            event.terminal = bool(terminal)
+        elif isinstance(event, EpisodeFinishEvent):
+            sim.episode_finish()
+        elif isinstance(event, FinishedEvent):
+            sim.close()
+            break
+        elif isinstance(event, UnknownEvent):
+            pass
+```
+
+## close()
+
+Close the internal websocket.
+
 ## operator<<(ostream, simulator)
 
 Prints out a representation of Simulator that is useful for debugging.

--- a/source/includes/library-reference/_simulator.html.md
+++ b/source/includes/library-reference/_simulator.html.md
@@ -73,7 +73,7 @@ of Simulator and implement the `episode_start` and `simulate` callbacks.
 | `brain`  |  A Brain object for the BRAIN you wish to train against. |
 | `name`   |  The name of simulator as specified in the Inkling for the BRAIN. |
 
-## Brain brain()
+## Brain brain
 
 ```python
 print(sim.brain)
@@ -81,14 +81,14 @@ print(sim.brain)
 
 Returns the BRAIN being used for this simulation.
 
-## name()
+## name
 
 ```python
 print("Starting ", sim.name)
 ```
 Returns the simulator name that was passed in when constructed.
 
-## predict()
+## predict
 
 ```python
 def simulate(self, action):
@@ -100,7 +100,7 @@ def simulate(self, action):
 
 Returns a value indicating whether the simulation is set up to run in predict mode or training mode.
 
-## objective_name()
+## objective_name
 
 ```python
 def episode_start(self, params):
@@ -235,7 +235,7 @@ def episode_finish(self):
 This callback is called at the end of each episode. You can use it to log
 out statistical information, or perform post episode cleanup.
 
-## record_file()
+## record_file
 
 ```python
 my_sim.record_file == "/path/to/foobar.json"

--- a/source/layouts/home.erb
+++ b/source/layouts/home.erb
@@ -106,8 +106,10 @@
 								<li><%= link_to 'API Reference', "/references/api-reference.html" %> </li>
 								<li><%= link_to 'CLI Reference', "/references/cli-reference.html" %> </li>
 								<li><%= link_to 'Inkling Reference', "/references/inkling-reference.html" %> </li>
-								<li><%= link_to 'Library Reference', "/references/library-reference.html" %> </li>
 								<li><%= link_to 'Simulator Reference', "/references/simulator-reference.html" %></li>
+								<li><%= link_to 'Python Library', "/references/library-reference.html" %> </li>
+								<li><%= link_to 'C++ Library', "/references/cpp-library-reference.html" %></li>
+								
 							</ul>
 						</div>
 					</div>

--- a/source/partials/_primary-nav.erb
+++ b/source/partials/_primary-nav.erb
@@ -38,8 +38,10 @@
 				<li class="<%= is_page_selected("/references/api-reference.html") %>"> <%= link_to 'API Reference', '/references/api-reference.html' %>  </li>
 				<li class="<%= is_page_selected("/references/cli-reference.html") %>"> <%= link_to 'CLI Reference', '/references/cli-reference.html' %>  </li>
 				<li class="<%= is_page_selected("/references/inkling-reference.html") %>"> <%= link_to 'Inkling Reference', '/references/inkling-reference.html' %>  </li>
-				<li class="<%= is_page_selected("/references/library-reference.html") %>"> <%= link_to 'Library Reference', '/references/library-reference.html' %>  </li>
 				<li class="<%= is_page_selected("/references/simulator-reference.html") %>"> <%= link_to 'Simulator Reference', '/references/simulator-reference.html' %>
+				<li class="<%= is_page_selected("/references/library-reference.html") %>"> <%= link_to 'Python Library', '/references/library-reference.html' %>  </li>
+				<li class="<%= is_page_selected("/references/cpp-library-reference.html") %>"> <%= link_to 'C++ Library', '/references/cpp-library-reference.html' %>  </li>
+				
 			</ul> 
 		</li>
 

--- a/source/references/cpp-library-reference.html.md
+++ b/source/references/cpp-library-reference.html.md
@@ -1,0 +1,17 @@
+---
+title: C++ Library Reference
+
+toc_footers:
+  -  <%= partial "partials/footer-links" %>
+
+includes:
+  - cpp-library-reference/introduction.html.md
+  - cpp-library-reference/brain.html.md
+  - cpp-library-reference/config.html.md
+  - cpp-library-reference/simulator.html.md
+  - cpp-library-reference/logger.html.md
+  - cpp-library-reference/event.html.md
+
+
+search: true
+---

--- a/source/references/library-reference.html.md
+++ b/source/references/library-reference.html.md
@@ -1,14 +1,8 @@
 ---
-title: Library Reference
-
-language_tabs:
-  - python
-  - cpp
+title: Python Library Reference
 
 toc_footers:
   -  <%= partial "partials/footer-links" %>
-
-
 
 includes:
   - library-reference/introduction.html.md

--- a/source/references/library-reference.html.md
+++ b/source/references/library-reference.html.md
@@ -17,6 +17,7 @@ includes:
   - library-reference/simulator.html.md
   - library-reference/predictor.html.md
   - library-reference/logger.html.md
+  - library-reference/event.html.md
 
 
 search: true


### PR DESCRIPTION
Hey ClientTools I need your help in making sure that I have split apart the C++ from the Python here appropriately and that everything is worded in a familiar way in Python to Python developers since originally all of this documentation came from the viewpoint of a C++ developer.

TODO:

* Fill in Event Class blurb for C++/Python
* Verify verbiage is standard for Python
* Make sure nothing is missing in Python

PR Review Checklist:
- [x] Test search functionality on desktop
- [x] Test search functionality on mobile
- [x] Test filter functionality
- [x] Test mobile header navigation
- [x] Test desktop header navigation
- [x] Test desktop homepage navigation
- [x] Run `npm run check-links` with 0 broken links
- [x] Run `npm run write-good <files being edited>` to "lint" the docs
