### PR TITLE
Update libbonsai ubuntu install docs

### DIFF
--- a/source/guides/sdk-install-guide.html.md
+++ b/source/guides/sdk-install-guide.html.md
@@ -3,7 +3,8 @@ title: Install the SDK
 
 language_tabs:
     - powershell: Windows
-    - shell: macOS
+    - shell--macos: macOS
+    - shell--ubuntu: Ubuntu
 
 toc_footers:
   -  <%= partial "partials/footer-links" %>    

--- a/source/includes/sdk-install-guide/_cpp-install.html.md
+++ b/source/includes/sdk-install-guide/_cpp-install.html.md
@@ -1,18 +1,37 @@
 # Install libbonsai for C++
 
 <aside class="warning">
-The C++ library is still in beta and currently only available on macOS.
+The C++ library is still in beta and currently only available on macOS and Ubuntu 16.04.
 </aside>
 
 ```powershell
 # Currently unavailable on Windows
 ```
 
-```shell
+```shell--macos
 $ brew install BonsaiAI/homebrew-bonsai/bonsai
 ```
 
-The C++ library `libbonsai` can currently be installed via Homebrew. The formula is hosted on BonsaiAI's GitHub, therefore the full link to the formula must be specified when using `brew` while it is in beta.
+```shell--ubuntu
+# Add url of libbonsai apt-repo to sources.list
+$ echo "deb [trusted=yes] https://libbonsai-debian.s3.amazonaws.com xenial main" >> /etc/apt/sources.list
+$ echo "deb-src [trusted=yes] https://libbonsai-debian.s3.amazonaws.com xenial main" >> /etc/apt/sources.list
+
+# Update package lists
+$ apt-get update
+
+# Install libbonsai
+$ apt-get install libbonsai
+
+# Get source
+$ apt-get source libbonsai
+```
+
+The C++ library `libbonsai` can currently be installed via Homebrew on macOS or via APT on Ubuntu. 
+
+The Homebrew formula is hosted on BonsaiAI's GitHub, therefore the full link to the formula must be specified when using `brew` while it is in beta.
+
+The APT package is in an apt-repo which is hosted on Amazon S3. The url of the apt-repo must be added to your `sources.list` before using `apt-get`.
 
 See the [C++ Library Reference][1] for full details on usage of this library.
 


### PR DESCRIPTION
- Added ubuntu tab
- updated c++ install docs
- No need to update python install as it carries over from the `shell--*` flag and the install is the same on osx/ubuntu