### PR TITLE
Update SDK with Windows VCPKG

### DIFF
--- a/source/includes/sdk-install-guide/_cpp-install.html.md
+++ b/source/includes/sdk-install-guide/_cpp-install.html.md
@@ -1,11 +1,17 @@
 # Install libbonsai for C++
 
-<aside class="warning">
-The C++ library is still in beta and currently only available on macOS and Ubuntu 16.04.
-</aside>
+```powershell
+# Build VCPKG
+cd C:\
+git clone https://github.com/BonsaiAI/vcpkg.git
+cd vcpkg
+.\bootstrap-vcpkg.bat
+.\vcpkg.exe integrate install
+```
 
 ```powershell
-# Currently unavailable on Windows
+# Build/Install libbonsai (incl dependencies):
+.\vcpkg.exe install bonsai:x64-windows-bns
 ```
 
 ```shell--macos
@@ -27,7 +33,9 @@ $ apt-get install libbonsai
 $ apt-get source libbonsai
 ```
 
-The C++ library `libbonsai` can currently be installed via Homebrew on macOS or via APT on Ubuntu. 
+The C++ library `libbonsai` can currently be installed via VCPKG on Windows, via Homebrew on macOS, or via APT on Ubuntu.
+
+The VCPKG is hosted on BonsaiAI's GitHub and must be cloned before you can build and install `libbonsai`.
 
 The Homebrew formula is hosted on BonsaiAI's GitHub, therefore the full link to the formula must be specified when using `brew` while it is in beta.
 

--- a/source/includes/sdk-install-guide/_overview.html.md
+++ b/source/includes/sdk-install-guide/_overview.html.md
@@ -6,19 +6,21 @@
 ###########################################################
 ```
 
-```shell
+```shell--macos
 #########################################################
 # macOS specific command prompt instructions shown here #
 #########################################################
 ```
 
+```shell--ubuntu
+#########################################################
+# Ubuntu specific command prompt instructions shown here #
+#########################################################
+```
 
-The Bonsai SDK is made up of a command line interface for interacting with and controlling BRAINs, a library for connecting simulations to a brain for training or predictions, and examples of simulators connecting to BRAINs. Bonsai libraries known as `libbonsai` (C++) and `bonsai-ai` (Python) wrap the Bonsai API to simplify the process of building simulators in C++ and Python programming languages. `bonsai-ai` is compatible with Python 2.7+ on Windows 7/10, macOS, and Linux.
 
-It is strongly suggested that you first follow our guide to [Install the CLI][1] so you can be sure to have any Python prerequisites already installed.
+The Bonsai SDK is made up of a command line interface for interacting with and controlling BRAINs, a library for connecting simulations to a brain for training or predictions, and examples of simulators connecting to BRAINs. Bonsai libraries known as `libbonsai` (C++) and `bonsai-ai` (Python) wrap the Bonsai API to simplify the process of building simulators in C++ and Python programming languages. `bonsai-ai` is compatible with Python 2.7+ on Windows 7/10, macOS, and Linux. `libbonsai` is compatible with Windows, macOS, and Ubuntu 16.04+.
 
-<aside class="warning">
-The C++ library is still in beta and currently only available on macOS.
-</aside>
+If installing `bonsai-ai` it is strongly suggested that you first follow our guide to [Install the CLI][1] so you can be sure to have any Python prerequisites already installed. Using `libbonsai` requires Microsoft Visual C++ 15 2017.
 
 [1]: ./cli-install-guide.html


### PR DESCRIPTION
Added Windows installation instructions to the SDK guide and removed the warnings about only building on mac.
