### PR TITLE
Add Predictor Cartpole example

### DIFF
--- a/source/examples.html.md
+++ b/source/examples.html.md
@@ -15,6 +15,7 @@ includes:
 - examples/tic-tac-toe.html.md
 - examples/mountain-car.html.md
 - examples/cartpole.html.md
+- examples/predictor-cartpole.html.md
 - examples/event-cartpole.html.md
 - examples/energyplus.html.md
 

--- a/source/includes/examples/_overview.html.md
+++ b/source/includes/examples/_overview.html.md
@@ -14,7 +14,8 @@ If you have any suggestions of examples you'd like to see us implement please [c
 ### OpenAI Gym Examples
 * **Mountain Car**: A simple control problem where a car must build up enough momentum to climb a hill.
 * **Cartpole**: A simple control problem where a cart must make a simple move to keep a pole balanced on top.
-* **Event Driven Cartpole**: Using the same Inkling at normal Cartpole, but using the Event class to drive the simulation.
+* **Predictor Class Cartpole**: Using the same Inkling as original Cartpole, but using the Predictor Class to obtain simulation predictions via Python script.
+* **Event Driven Cartpole**: Using the same Inkling as original Cartpole, but using the Event class to drive the simulation.
 
 ### Real World Example
 * **HVAC with EnergyPlus**: An example of climate control machine teaching using EnergyPlus and BCVTB for simulation.

--- a/source/includes/examples/predictor-cartpole.html.md
+++ b/source/includes/examples/predictor-cartpole.html.md
@@ -1,0 +1,151 @@
+# Predictor Class Cartpole
+
+> ![Cartpole Balance](../images/cart-pole-balance.gif)
+
+[**Download the full source code on GitHub**][1] if you want to run this simulator.
+
+This example demonstrates how the `Predictor` class can be used to obtain predictions from a trained BRAIN. This is an alternative method to using the CLI to obtain predictions using the `--predict` flag with Bonsai's Python SDK.
+
+Cartpole is a classic control problem. [OpenAI Gym][2] describes it as:
+
+_A pole is attached by an un-actuated joint to a cart, which moves along a frictionless track. The system is controlled by applying a force of +1 or -1 to the cart. The pendulum starts upright, and the goal is to prevent it from falling over. A reward of +1 is provided for every timestep that the pole remains upright. The episode ends when the pole is more than 15 degrees from vertical, or the cart moves more than 2.4 units from the center._
+
+## Inkling File
+
+The Inkling for this example is exactly the same as the original [Cartpole OpenAI Gym example][4] above. See the previous example for details on how the Inkling works for training cartpole.
+
+
+## Simulator File
+
+> cartpole_simulator.py
+
+```python
+import sys
+import logging
+from bonsai_ai import Brain, Config
+from bonsai_gym import GymSimulator
+
+log = logging.getLogger('gym_simulator')
+log.setLevel(logging.DEBUG)
+
+
+class CartPole(GymSimulator):
+    # Environment name, from openai-gym
+    environment_name = 'CartPole-v0'
+
+    # simulator name from Inkling
+    # Example Inkling:
+    #   curriculum balance_curriculum
+    #       train balance
+    #       with simulator cartpole_simulator
+    #       ....
+    simulator_name = 'cartpole_simulator'
+
+    # convert openai gym observation to our state schema
+    # Example Inkling:
+    #   schema GameState
+    #       Float32 position,
+    #       Float32 velocity,
+    #       Float32 angle,
+    #       Float32 rotation
+    #   end
+    def gym_to_state(self, observation):
+        state = {'position': observation[0],
+                 'velocity': observation[1],
+                 'angle':    observation[2],
+                 'rotation': observation[3]}
+        return state
+
+    # convert our action schema into openai gym action
+    # Example Inkling:
+    #   schema Action
+    #       Int8{0, 1} command
+    #   end
+    def action_to_gym(self, action):
+        return action['command']
+
+
+if __name__ == '__main__':
+    # create a brain, openai-gym environment, and simulator
+    config = Config(sys.argv)
+    brain = Brain(config)
+    sim = CartPole(brain)
+    sim.run_gym()
+
+```
+
+This is an OpenAI Gym example which uses the OpenAI environment as its simulator. For more information about the simulator used see the [Bonsai Gym][3] folder in the bonsai-sdk GitHub repo which is a python library for integrating a Bonsai BRAIN with OpenAI Gym environments.
+
+## Predictor File
+
+> cartpole_predictor.py
+
+```python
+import sys
+import gym
+from bonsai_ai import Brain, Config, Predictor
+from bonsai_ai.logger import Logger
+
+log = Logger()
+log.set_enabled("info")
+
+
+def _state(observation):
+    """ Converts gym observation into Inkling state dictionary """
+    state = {'position': observation[0],
+             'velocity': observation[1],
+             'angle':    observation[2],
+             'rotation': observation[3]}
+    return state
+
+
+def _action(action):
+    """ Converts Inkling action into a gym action """
+    return action['command']
+
+
+def _log_state_and_action(state, action):
+    log.info("The BRAIN received the following state: {}".format(state))
+    log.info("The BRAIN returned the following action: {}".format(action))
+
+
+if __name__ == '__main__':
+    # Set up predictor
+    config = Config(sys.argv)
+    brain = Brain(config)
+    predictor = Predictor(brain, 'cartpole_simulator')
+
+    # Set up cartpole simulator
+    episode_count = 10
+    env = gym.make('CartPole-v0')
+
+    # Reset, get state, exchange state for action, and then step the sim
+    observation = env.reset()
+    state = _state(observation)
+    action = _action(predictor.get_action(state))
+    _log_state_and_action(state, action)
+    observation, reward, done, info = env.step(action)
+    env.render()
+
+    # Loop until episode_count is reached
+    while episode_count:
+        state = _state(observation)
+        action = _action(predictor.get_action(state))
+        _log_state_and_action(state, action)
+        observation, reward, done, info = env.step(action)
+        env.render()
+
+        if done:
+            episode_count -= 1
+            observation = env.reset()
+
+```
+
+This `cartpole_predictor.py` file contains all the code necessary to obtain predictions from a trained BRAIN. This predictor file converts the action and state spaces from the cartpole simulator (this is the same simulator as the original OpenAI Gym example) and logs the prediction results.
+
+
+[1]: https://github.com/BonsaiAI/bonsai-sdk/tree/master/samples/openai-gym/gym-cartpole-predictor-sample
+[2]: https://gym.openai.com/envs/CartPole-v1
+[3]: https://github.com/BonsaiAI/bonsai-sdk/tree/master/bonsai-gym
+[4]: #openai-gym-cartpole
+[5]: ../references/library-reference.html#predictor-class


### PR DESCRIPTION
Add the Predictor Class cartpole example to the docs page and added it to the overview section of the examples page.

PR Review Checklist:
- [x] Test search functionality on desktop
- [x] Test search functionality on mobile
- [x] Test filter functionality
- [x] Test mobile header navigation
- [x] Test desktop header navigation
- [x] Test desktop homepage navigation
- [x] Run `npm run check-links` with 0 broken links
- [ ] Run `npm run write-good <files being edited>` to "lint" the docs
