### PR TITLE
Removing reference to the simulator logs endpoint

### DIFF
--- a/source/includes/api-reference/_api-reference.html.md
+++ b/source/includes/api-reference/_api-reference.html.md
@@ -540,26 +540,6 @@ GET /v1/{userName}/{brainName}/sims
 | connected | Count of how many simulators are connected |
 | instances | Array of connected simulators with their status and episode count |
 
-## Simulator Logs
-
-GET log messages from platform-managed simulators.
-
-> Request
-
-```text
-GET /v1/{userName}/{brainName}/{brainVersion}/sims/1/logs
-```
-
-| Parameter | Description |
-| --- | --- |
-| userName | Name of the user who has the BRAIN |
-| brainName | Name of the BRAIN |
-| brainVersion | Version of the BRAIN |
-
-### Response
-
-The request will return an array of strings (each string representing one log message). 
-
 ## Simulator Logs Websocket
 
 Use the websocket connection to get real-time simulator messages during training.


### PR DESCRIPTION
Having been deprecated, this endpoint should be removed from the documentation so that people don't try to hit it (and fail).

!!!!! STOP AND READ !!!!!

If the dropdown above says "base fork: lord/master", click "base fork" to change it to the bonsaiai.github.io on the `dev` branch, *NOT `master` branch*.

PR Review Checklist:
- [ ] Test search functionality on desktop
- [ ] Test search functionality on mobile (Chrome dev tools)
- [ ] Test filter functionality
- [ ] Test mobile header navigation
- [ ] Test desktop header navigation
- [ ] Test desktop homepage navigation
- [ ] Run `npm run check-links` with 0 broken links
- [ ] Run `npm run write-good <files being edited>` to "lint" the docs
